### PR TITLE
Add special "move task to error queue" error to the worker.

### DIFF
--- a/mem/mem_test.go
+++ b/mem/mem_test.go
@@ -72,6 +72,18 @@ func TestSimpleWorker(t *testing.T) {
 	qtest.SimpleWorker(ctx, t, client, "")
 }
 
+func TestWorkerMoveOnError(t *testing.T) {
+	ctx := context.Background()
+
+	client, stop, err := qtest.ClientService(ctx, Opener())
+	if err != nil {
+		t.Fatalf("Get client: %v", err)
+	}
+	defer stop()
+
+	qtest.WorkerMoveOnError(ctx, t, client, "")
+}
+
 func TestWorkerRenewal(t *testing.T) {
 	ctx := context.Background()
 

--- a/pg/pg_test.go
+++ b/pg/pg_test.go
@@ -114,6 +114,19 @@ func TestSimpleWorker(t *testing.T) {
 	qtest.SimpleWorker(ctx, t, client, "pgtest/"+uuid.New().String())
 }
 
+func TestWorkerMoveOnError(t *testing.T) {
+	ctx := context.Background()
+
+	client, stop, err := pgClient(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create pg service and client: %v", err)
+	}
+	defer stop()
+
+	log.Printf("Worker move on error")
+	qtest.WorkerMoveOnError(ctx, t, client, "pgtest/"+uuid.New().String())
+}
+
 func TestWorkerRenewal(t *testing.T) {
 	ctx := context.Background()
 

--- a/worker.go
+++ b/worker.go
@@ -120,9 +120,8 @@ func (w *Worker) Run(ctx context.Context, f func(ctx context.Context, task *Task
 			}
 			return nil
 		})
-
 		if err != nil {
-			log.Printf("Worker error (%q): %T %v", w.Q, err, err)
+			log.Printf("Worker error (%q): %v", w.Q, err)
 			if _, ok := AsDependency(err); ok {
 				log.Printf("Worker continuing after dependency (%q)", w.Q)
 				continue
@@ -146,7 +145,6 @@ func (w *Worker) Run(ctx context.Context, f func(ctx context.Context, task *Task
 				}
 				return nil
 			}
-
 			return errors.Wrapf(err, "worker error (%q)", w.Q)
 		}
 


### PR DESCRIPTION
Referencing issue #3, implements a "move on error" error type that can be returned from a worker's Run function to cause the task under consideration to be moved to a pre-defined error queue instead of merely deleted (no error) or causing the worker to crash (a normal error).