### PR TITLE
postgres docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ WORKDIR /go/bin
 RUN adduser -S -D -H -h /go/src/entrogo.com/entroq -u 100 appuser
 USER appuser
 
+EXPOSE 37706
+
 ENTRYPOINT ["./eqsvc.sh"]
 
 # Defalts to starting up an in-memory queue service on the default port.

--- a/pg/Dockerfile
+++ b/pg/Dockerfile
@@ -1,0 +1,53 @@
+# Inspired by https://www.cloudreach.com/blog/containerize-this-golang-dockerfiles/
+
+# Build inside a Go container.
+FROM golang:1.14-stretch as builder
+
+ENV GOPATH /build
+ENV CGO_ENABLED 0
+
+COPY . $GOPATH/src/entrogo.com/entroq
+WORKDIR $GOPATH/src/entrogo.com/entroq
+
+RUN apt-get install -y git
+RUN go get -d -v ./... && go install -v ./...
+
+# Also build parallel from source, embed in a script, and then we can make our command from that.
+RUN mkdir -p /tmp/src \
+ && cd /tmp/src \
+ && apt-get update \
+ && apt-get install -y curl bzip2 make \
+ && curl -LO https://ftp.gnu.org/gnu/parallel/parallel-20201022.tar.bz2 \
+ && tar xjf parallel-20201022.tar.bz2 \
+ && cd parallel-20201022 \
+ && ./configure \
+ && make \
+ && make install
+
+RUN parallel --embed | head -n -6 > eqpluspg.sh \
+ && echo 'parallel --halt now,done=1 ::: "docker-entrypoint.sh postgres" "eqsvc.sh pg --port=37706"' >> eqpluspg.sh \
+ && chmod +x eqpluspg.sh \
+ && mv eqpluspg.sh /build/bin/
+
+
+
+# Switch to the Postgres container - based on stretch. We'll copy
+# Our tool binaries into this one and change the entrypoint.
+FROM postgres:11.1
+
+RUN mkdir -p /go/bin \
+ && mkdir -p $HOME/.parallel \
+ && touch $HOME/.parallel/will-cite
+
+COPY --from=builder /build/bin/* /go/bin/
+ENV PATH ${PATH}:/go/bin
+
+COPY cmd/eqsvc.sh /go/bin/
+WORKDIR /go/bin
+
+EXPOSE 37706
+VOLUME /var/lib/postgresql/data
+
+
+# TODO: fix entrypoint to call postgres, tini, etc.
+CMD ["eqpluspg.sh"]

--- a/pg/Dockerfile
+++ b/pg/Dockerfile
@@ -24,10 +24,10 @@ RUN mkdir -p /tmp/src \
  && make \
  && make install
 
-RUN parallel --embed | head -n -6 > eqpluspg.sh \
- && echo 'parallel --halt now,done=1 ::: "docker-entrypoint.sh postgres" "eqsvc.sh pg --port=37706"' >> eqpluspg.sh \
- && chmod +x eqpluspg.sh \
- && mv eqpluspg.sh /build/bin/
+RUN parallel --embed | head -n -6 > eq_and_pg.sh \
+ && echo 'parallel --halt now,done=1 ::: "docker-entrypoint.sh postgres" "eqsvc.sh pg --port=37706"' >> eq_and_pg.sh \
+ && chmod +x eq_and_pg.sh \
+ && mv eq_and_pg.sh /build/bin/
 
 
 
@@ -49,5 +49,4 @@ EXPOSE 37706
 VOLUME /var/lib/postgresql/data
 
 
-# TODO: fix entrypoint to call postgres, tini, etc.
-CMD ["eqpluspg.sh"]
+CMD ["eq_and_pg.sh"]

--- a/pg/Dockerfile
+++ b/pg/Dockerfile
@@ -24,6 +24,15 @@ RUN mkdir -p /tmp/src \
  && make \
  && make install
 
+# Create a GNU parallel script that can run both postgres and eqsvc
+# simultaneously, configured to stop everything if either one goes down
+# (--halt).
+#
+# The docker-entrypoint.sh script comes from the postgres base image.
+# The eqsvc.sh script comes from our builder base image.
+#
+# Note that we cut out the last 6 lines of the embedded parallel script: these
+# are noisy example invocations, so we don't need them.
 RUN parallel --embed | head -n -6 > eq_and_pg.sh \
  && echo 'parallel --halt now,done=1 ::: "docker-entrypoint.sh postgres" "eqsvc.sh pg --port=37706"' >> eq_and_pg.sh \
  && chmod +x eq_and_pg.sh \

--- a/pg/pg_test.go
+++ b/pg/pg_test.go
@@ -307,7 +307,7 @@ func startPostgres(ctx context.Context) (port int, stop func(), err error) {
 	name := fmt.Sprintf("testpg-%s", uuid.New())
 
 	log.Printf("Starting postgres container %q...", name)
-	if err := run(ctx, "docker", "run", "-p", "0:5432", "--rm", "-d", "--name", name, "postgres"); err != nil {
+	if err := run(ctx, "docker", "run", "-p", "0:5432", "--rm", "-d", "-e", "POSTGRES_PASSWORD=postgres", "--name", name, "postgres:11"); err != nil {
 		return 0, nil, errors.Wrap(err, "start postgres container")
 	}
 	time.Sleep(2 * time.Second) // give it some time to get pipes attached


### PR DESCRIPTION
Make a Dockerfile that runs eqsvc and postgres together, under GNU parallel (ensuring that killing one kills the other). This makes it easier to deploy eqsvc as a single container and still get persistence (just mount something into /var/lib/postgresql/data).

Also add postgres password to the test, in case a newer database version is used that is fussier about that.