### PR TITLE
Add queue name functions for namespaces.

### DIFF
--- a/entroq.go
+++ b/entroq.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"entrogo.com/entroq/queues"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -92,11 +91,6 @@ func (t *TaskData) String() string {
 	return s
 }
 
-// Namespace returns the namespace from this queue name, if any.
-func (t *TaskData) Namespace() (string, bool) {
-	return queues.Namespace(t.Queue)
-}
-
 // Task represents a unit of work, with a byte slice value payload.
 // Note that Claims is the number of times a task has successfully been claimed.
 // This is different than the version number, which increments for
@@ -123,11 +117,6 @@ func (t *Task) String() string {
 		fmt.Sprintf("c=%q m=%q", t.Created, t.Modified),
 		fmt.Sprintf("val=%q", string(t.Value)),
 	}, "\n\t") + "\n"
-}
-
-// Namespace returns the namespace of this task's queue, if present. Can be empty when present.
-func (t *Task) Namespace() (string, bool) {
-	return queues.Namespace(t.Queue)
 }
 
 // AsDeletion returns a ModifyArg that can be used in the Modify function, e.g.,

--- a/entroq.go
+++ b/entroq.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"entrogo.com/entroq/queues"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -91,6 +92,11 @@ func (t *TaskData) String() string {
 	return s
 }
 
+// Namespace returns the namespace from this queue name, if any.
+func (t *TaskData) Namespace() (string, bool) {
+	return queues.Namespace(t.Queue)
+}
+
 // Task represents a unit of work, with a byte slice value payload.
 // Note that Claims is the number of times a task has successfully been claimed.
 // This is different than the version number, which increments for
@@ -117,6 +123,11 @@ func (t *Task) String() string {
 		fmt.Sprintf("c=%q m=%q", t.Created, t.Modified),
 		fmt.Sprintf("val=%q", string(t.Value)),
 	}, "\n\t") + "\n"
+}
+
+// Namespace returns the namespace of this task's queue, if present. Can be empty when present.
+func (t *Task) Namespace() (string, bool) {
+	return queues.Namespace(t.Queue)
 }
 
 // AsDeletion returns a ModifyArg that can be used in the Modify function, e.g.,

--- a/queues/queues.go
+++ b/queues/queues.go
@@ -1,0 +1,94 @@
+// Package queues contains helper functions for manipulation of queue names.
+package queues // import entrogo.com/entroq/queues
+
+import (
+	"path"
+	"strings"
+)
+
+// EscapeComponent adds backslash in front of backslash and forward slash.
+func EscapeComponent(c string) string {
+	replacer := strings.NewReplacer("/", "\\/", "\\", "\\\\")
+	return replacer.Replace(c)
+}
+
+// PathComponents returns a list of the path components in this queue
+// name. It basically assumes that the name is structured like a POSIX file
+// path, including escaping of / where needed. It includes the beginning '/' as
+// part of the component, if it has one. A path ending in / will have a final
+// component of just that character.
+func PathComponents(qname string) []string {
+	var components []string
+	buf := ""
+	isEsc := false
+	for _, c := range qname {
+		if !isEsc && c == '/' && buf != "" {
+			// Time to ship out a component, reset the buffer.
+			components = append(components, buf)
+			buf = ""
+		}
+		if c != '\\' || isEsc {
+			buf += string(c)
+		}
+		isEsc = c == '\\' && !isEsc
+	}
+	if buf != "" {
+		components = append(components, buf)
+	}
+	return components
+}
+
+// PathParams returns a map from strings to slices of values. It looks
+// through the queue name, assuing that it is basically structured like a path,
+// with some `/key=value/` components, and extracts those key/value pairs into
+// what is essentially a multimap.
+//
+// Note that `/key=` is the criterion for search. If the key=value does not
+// start with a slash, it is not picked up. This allows for escaping of the /
+// character, so `\/` cannot start one of these path components.
+func PathParams(qname string) map[string][]string {
+	params := make(map[string][]string)
+	for _, component := range PathComponents(qname) {
+		if !strings.HasPrefix(component, "/") {
+			continue
+		}
+		// Remove the prefix, which we know uses 1 byte, now:
+		keyVal := component[1:]
+
+		pieces := strings.SplitN(keyVal, "=", 2)
+		if len(pieces) != 2 {
+			continue
+		}
+		key, val := pieces[0], pieces[1]
+		params[key] = append(params[key], val)
+	}
+	if len(params) == 0 {
+		return nil
+	}
+	return params
+}
+
+// Namespace returns the namespace component from a queue name, if it exists.
+func Namespace(qname string) (string, bool) {
+	if qname == "" {
+		return "", false
+	}
+	if !strings.HasPrefix(qname, "/ns=") {
+		return "", false
+	}
+	// Starts with /ns=, so get the next component from that.
+	params := PathParams(qname)
+	if ns, ok := params["ns"]; ok {
+		return ns[0], true // only the first one matters.
+	}
+	return "", false
+}
+
+// TryAddNamespace attempts to add the given namespace to the queue name. If
+// there is already a namespace, it gives up. Otherwise it prepends with /ns=namespace/.
+func TryAddNamespace(qname, ns string) string {
+	if _, ok := Namespace(qname); ok {
+		return qname
+	}
+	return path.Join("/ns="+EscapeComponent(ns), qname)
+}

--- a/queues/queues_test.go
+++ b/queues/queues_test.go
@@ -1,0 +1,251 @@
+package queues
+
+import (
+	"log"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNamespace(t *testing.T) {
+	cases := []struct {
+		name  string
+		queue string
+		ok    bool
+		want  string
+	}{
+		{
+			name:  "no ns",
+			queue: "/some/path/somewhere",
+		},
+		{
+			name:  "not a path",
+			queue: "this is not a path",
+		},
+		{
+			name:  "simple ns",
+			queue: "/ns=something/and/other/stuff",
+			ok:    true,
+			want:  "something",
+		},
+		{
+			name:  "double ns",
+			queue: "/ns=something/and/ns=other/",
+			ok:    true,
+			want:  "something",
+		},
+		{
+			name:  "no leading slash",
+			queue: "ns=myns/not/really",
+		},
+		{
+			name:  "not first component",
+			queue: "/hey/ns=something/there",
+		},
+		{
+			name:  "escaped slash",
+			queue: "/ns=some\\/thing/hey",
+			ok:    true,
+			want:  "some/thing",
+		},
+	}
+
+	for _, test := range cases {
+		ns, ok := Namespace(test.queue)
+		if test.ok != ok {
+			t.Errorf("TestNamespace %q: wanted ok=%v, got %v", test.name, test.ok, ok)
+		}
+		if test.want != ns {
+			t.Errorf("TestNamespace %q: wanted ns=%v, got %v", test.name, test.want, ns)
+		}
+	}
+}
+
+func TestPathParams(t *testing.T) {
+	cases := []struct {
+		name  string
+		queue string
+		want  map[string][]string
+	}{
+		{
+			name:  "no params",
+			queue: "/some/path/somewhere",
+		},
+		{
+			name:  "leading param",
+			queue: "/key=someval/hello",
+			want: map[string][]string{
+				"key": []string{"someval"},
+			},
+		},
+		{
+			name:  "multiple same",
+			queue: "/hey there/key=someval/and stuff/key=otherval",
+			want: map[string][]string{
+				"key": []string{"someval", "otherval"},
+			},
+		},
+		{
+			name:  "escaped key",
+			queue: "/n\\/s=something/hey",
+			want: map[string][]string{
+				"n/s": []string{"something"},
+			},
+		},
+		{
+			name:  "escaped value",
+			queue: "/key=val\\/ue/hey",
+			want: map[string][]string{
+				"key": []string{"val/ue"},
+			},
+		},
+		{
+			name:  "terminal value, no slash",
+			queue: "/hey there/key=value",
+			want: map[string][]string{
+				"key": []string{"value"},
+			},
+		},
+		{
+			name:  "repeated terminal",
+			queue: "/hey/k=something/there/k=else",
+			want: map[string][]string{
+				"k": []string{"something", "else"},
+			},
+		},
+		{
+			name:  "leading without slash prefix",
+			queue: "key=something/and/other/stuff",
+		},
+	}
+
+	for _, test := range cases {
+		params := PathParams(test.queue)
+		if diff := cmp.Diff(test.want, params); diff != "" {
+			log.Printf("want %v, got %v", test.want, params)
+			t.Errorf("TestPathParams %q (-want +got):\n%v", test.name, diff)
+		}
+	}
+}
+
+func TestPathComponents(t *testing.T) {
+	cases := []struct {
+		name  string
+		queue string
+		want  []string
+	}{
+		{
+			name:  "empty",
+			queue: "",
+		},
+		{
+			name:  "no slashes",
+			queue: "hey there",
+			want:  []string{"hey there"},
+		},
+		{
+			name:  "one with prefix",
+			queue: "/hey there",
+			want:  []string{"/hey there"},
+		},
+		{
+			name:  "trailing slash",
+			queue: "/hey there/and stuff/",
+			want:  []string{"/hey there", "/and stuff", "/"},
+		},
+		{
+			name:  "escaping",
+			queue: "/hey\\/there/and\\/stuff\\//",
+			want:  []string{"/hey/there", "/and/stuff/", "/"},
+		},
+	}
+
+	for _, test := range cases {
+		if diff := cmp.Diff(test.want, PathComponents(test.queue)); diff != "" {
+			t.Errorf("TestPathComponents %q (-want +got):\n%v", test.name, diff)
+		}
+	}
+}
+
+func TestEscapeComponent(t *testing.T) {
+	cases := []struct {
+		name      string
+		component string
+		want      string
+	}{
+		{
+			name:      "nothing to escape",
+			component: "lots of stuff, none of it weird",
+			want:      "lots of stuff, none of it weird",
+		},
+		{
+			name: "empty",
+		},
+		{
+			name:      "forward slashes",
+			component: "something/in/here/needs/escaping/",
+			want:      "something\\/in\\/here\\/needs\\/escaping\\/",
+		},
+		{
+			name:      "backslash",
+			component: "something\\is\\strange\\here",
+			want:      "something\\\\is\\\\strange\\\\here",
+		},
+		{
+			name:      "consecutive backslashes and slashes",
+			component: "a/\\\\//",
+			want:      "a\\/\\\\\\\\\\/\\/",
+		},
+		{
+			name:      "trailing backslash",
+			component: "a\\",
+			want:      "a\\\\",
+		},
+	}
+
+	for _, test := range cases {
+		if got, want := EscapeComponent(test.component), test.want; got != want {
+			t.Errorf("TestEscapeComponent %q: expected %q, got %q", test.name, want, got)
+		}
+	}
+}
+
+func TestTryAddNamespace(t *testing.T) {
+	cases := []struct {
+		name      string
+		queue     string
+		namespace string
+		want      string
+	}{
+		{
+			name:      "empty namespace",
+			queue:     "no matter",
+			namespace: "",
+			want:      "/ns=/no matter",
+		},
+		{
+			name:      "already namespaced",
+			queue:     "/ns=something/other stuff",
+			namespace: "other",
+			want:      "/ns=something/other stuff",
+		},
+		{
+			name:      "invalid namespace exists",
+			queue:     "ns=hey/there",
+			namespace: "namespace",
+			want:      "/ns=namespace/ns=hey/there",
+		},
+		{
+			name:      "no namespace yet",
+			queue:     "/this/is/a/path",
+			namespace: "namesy",
+			want:      "/ns=namesy/this/is/a/path",
+		},
+	}
+
+	for _, test := range cases {
+		if got, want := TryAddNamespace(test.queue, test.namespace), test.want; got != want {
+			t.Errorf("TestTryAddNamespace %q: expected %q, got %q", test.name, want, got)
+		}
+	}
+}


### PR DESCRIPTION
This is a partial implementation of the [[Namespaces Proposal]] document. It adds functions to Task and TaskData to get the namespace from the queue name, if needed, and provides helper functions that can be used (and eventually will be) to automatically add namespaces.

The important thing is that there is now a standard way to add and extract namespaces, and to escape path components, should that be desirable.