### PR TITLE
word-stuffed log implementation - basic library

### DIFF
--- a/pkg/stuffedio/stuffedio.go
+++ b/pkg/stuffedio/stuffedio.go
@@ -114,6 +114,8 @@ func (w *Writer) Append(p []byte) error {
 	}
 	// If the last pass through found a reserved sequence, then that means
 	// it _ended_ with a reserved sequence. That means we need an empty record to terminate.
+	// Empty records indicate "the whole thing was a delimiter" (zero
+	// non-delimiter bytes, which is less than the record max).
 	if foundReserved {
 		if _, err := buf.Write([]byte{0, 0}); err != nil {
 			return fmt.Errorf("write rec: %w", err)

--- a/pkg/stuffedio/stuffedio.go
+++ b/pkg/stuffedio/stuffedio.go
@@ -253,15 +253,15 @@ func (r *Reader) Next() ([]byte, error) {
 		return nil, io.EOF
 	}
 
-	// Find the first real delimiter. This can help get things on track after a
-	// corrupt record, or at the start of a shard that comes in the middle of a
-	// record. We strictly require every record to be prefixed with the
-	// delimiter, including the first, allowing this logic to work properly.
-	if err := r.discardToDelimiter(); err != nil {
-		return nil, fmt.Errorf("next: %w", err)
-	}
-
 	if !r.discardLeader() {
+		// Find the first real delimiter for next time. This can help get
+		// things on track after a corrupt record, or at the start of a shard
+		// that comes in the middle of a record. We strictly require every
+		// record to be prefixed with the delimiter, including the first,
+		// allowing this logic to work properly.
+		if err := r.discardToDelimiter(); err != nil {
+			return nil, fmt.Errorf("next: error discarding to next delimiter after corruption: %w", err)
+		}
 		return nil, fmt.Errorf("next: no leading delimiter in record: %w", CorruptRecord)
 	}
 

--- a/pkg/stuffedio/stuffedio.go
+++ b/pkg/stuffedio/stuffedio.go
@@ -112,6 +112,13 @@ func (w *Writer) Append(p []byte) error {
 		}
 		p = p[end:]
 	}
+	// If the last pass through found a reserved sequence, then that means
+	// it _ended_ with a reserved sequence. That means we need an empty record to terminate.
+	if foundReserved {
+		if _, err := buf.Write([]byte{0, 0}); err != nil {
+			return fmt.Errorf("write rec: %w", err)
+		}
+	}
 	if _, err := io.Copy(w.dest, buf); err != nil {
 		return fmt.Errorf("write rec: %w", err)
 	}

--- a/pkg/stuffedio/stuffedio.go
+++ b/pkg/stuffedio/stuffedio.go
@@ -229,7 +229,7 @@ func (r *Reader) scanN(n int) []byte {
 // discardToDelimiter attempts to read until it finds a delimiter. Assumes that
 // the buffer begins full. It may be filled again, in here.
 func (r *Reader) discardToDelimiter() error {
-	for !r.atDelimiter() {
+	for !r.atDelimiter() && !r.Done() {
 		r.scanN(r.end - r.pos)
 		if err := r.fillBuf(); err != nil {
 			return fmt.Errorf("discard: %w", err)
@@ -245,12 +245,12 @@ func (r *Reader) discardToDelimiter() error {
 // record to begin with a delimiter. Returns a wrapped io.EOF when complete.
 // More idiomatically, check Done after every iteration.
 func (r *Reader) Next() ([]byte, error) {
-	if r.Done() {
-		return nil, io.EOF
-	}
 	buf := new(bytes.Buffer)
 	if err := r.fillBuf(); err != nil {
 		return nil, fmt.Errorf("next: %w", err)
+	}
+	if r.Done() {
+		return nil, io.EOF
 	}
 
 	// Find the first real delimiter. This can help get things on track after a

--- a/pkg/stuffedio/stuffedio_test.go
+++ b/pkg/stuffedio/stuffedio_test.go
@@ -31,7 +31,7 @@ func Example() {
 	// A very short message
 }
 
-func TestWriter_Append_short(t *testing.T) {
+func TestWriter_Append(t *testing.T) {
 	cases := []struct {
 		name  string
 		write string
@@ -45,10 +45,16 @@ func TestWriter_Append_short(t *testing.T) {
 			want:  "Short message",
 		},
 		{
-			name:  "with-delimiters",
+			name:  "tail-delimiters",
 			write: "short\xfe\xfd",
-			raw:   "\xfe\xfd\x05short",
+			raw:   "\xfe\xfd\x05short\x00\x00",
 			want:  "short\xfe\xfd",
+		},
+		{
+			name:  "leading-delimiters",
+			write: "\xfe\xfdshort",
+			raw:   "\xfe\xfd\x00\x05\x00short",
+			want:  "\xfe\xfdshort",
 		},
 	}
 

--- a/pkg/stuffedio/stuffedio_test.go
+++ b/pkg/stuffedio/stuffedio_test.go
@@ -187,8 +187,8 @@ func TestReader_Next_corrupt(t *testing.T) {
 		},
 		{
 			name: "garbage-in-middle",
-			raw:  "\xfe\xfd\x02AB\xfe\xfdrandom crap\xfe\xfd\x02BC",
-			want: []string{"AB", "", "BC"},
+			raw:  "\xfe\xfd\x02AB\xfe\xfdrandom crap\xfe\xfd\x02BC\xfe\xfd\x02CD",
+			want: []string{"AB", "", "BC", "CD"},
 		},
 	}
 

--- a/pkg/stuffedio/stuffedio_test.go
+++ b/pkg/stuffedio/stuffedio_test.go
@@ -2,9 +2,13 @@ package stuffedio
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func ExampleWriter_Append() {
@@ -64,6 +68,21 @@ func TestWriter_Append_one(t *testing.T) {
 			raw:   "\xfe\xfd\x05short\x07\x00message",
 		},
 		{
+			name:  "partial-delimiters",
+			write: "short\xfemessage",
+			raw:   "\xfe\xfd\x0dshort\xfemessage",
+		},
+		{
+			name:  "second-half-delimiters",
+			write: "short\xfdmessage",
+			raw:   "\xfe\xfd\x0dshort\xfdmessage",
+		},
+		{
+			name:  "empty",
+			write: "",
+			raw:   "",
+		},
+		{
 			name:  "longer-message",
 			write: "This is a much longer message, containing many more characters than can fit into a single short message of 252 characters. It kind of rambles on, as a result. Good luck figuring out where the break needs to be! It turns out that 252 bytes is really quite a lot of text for a short test like this.",
 			raw:   "\xfe\xfd\xfcThis is a much longer message, containing many more characters than can fit into a single short message of 252 characters. It kind of rambles on, as a result. Good luck figuring out where the break needs to be! It turns out that 252 bytes is really qui\x2c\x00te a lot of text for a short test like this.",
@@ -73,27 +92,109 @@ func TestWriter_Append_one(t *testing.T) {
 			write: "This is a much longer message, containing many more characters than can fit into a single short message of 252 characters. It kind of rambles on, as a result. Good luck figuring out where the break needs to be! It turns out that 252 bytes is really quite a lot of text for a short test like this.\xfe\xfd",
 			raw:   "\xfe\xfd\xfcThis is a much longer message, containing many more characters than can fit into a single short message of 252 characters. It kind of rambles on, as a result. Good luck figuring out where the break needs to be! It turns out that 252 bytes is really qui\x2c\x00te a lot of text for a short test like this.\x00\x00",
 		},
+		{
+			name:  "longer-message-with-split-delimiter",
+			write: "This is a much longer message, containing many more characters than can fit into a single short message of 252 characters. It kind of rambles on, as a result. Good luck figuring out where the break needs to be! It turns out that 252 bytes is really qu\xfe\xfdite a lot of text for a short test like this.\xfe\xfd",
+			raw:   "\xfe\xfd\xfcThis is a much longer message, containing many more characters than can fit into a single short message of 252 characters. It kind of rambles on, as a result. Good luck figuring out where the break needs to be! It turns out that 252 bytes is really qu\xfe\x2e\x00\xfdite a lot of text for a short test like this.\x00\x00",
+		},
 	}
 
 	for _, test := range cases {
 		buf := new(bytes.Buffer)
 		w := NewWriter(buf)
 		if err := w.Append([]byte(test.write)); err != nil {
-			t.Fatalf("Append_short %q: writing: %v", test.name, err)
+			t.Fatalf("Append_one %q: writing: %v", test.name, err)
 		}
 		if want, got := []byte(test.raw), buf.Bytes(); !bytes.Equal(want, got) {
-			t.Fatalf("Append_short %q: want raw %q, got %q", test.name, string(want), string(got))
+			t.Fatalf("Append_one %q: want raw %q, got %q", test.name, string(want), string(got))
 		}
 		r := NewReader(buf)
 		b, err := r.Next()
-		if err != nil {
-			t.Fatalf("Append_short %q: reading: %v", test.name, err)
+		switch {
+		case test.raw == "" && !errors.Is(err, io.EOF):
+			t.Fatalf("Append_one %q: expected EOF, got %v with value %q", test.name, err, string(b))
+		case test.raw == "" && errors.Is(err, io.EOF):
+			// Do nothing
+		case err != nil:
+			t.Fatalf("Append_one %q: reading: %v", test.name, err)
 		}
 		if want, got := test.write, string(b); want != got {
-			t.Errorf("Append_short %q: wanted read %q, got %q", test.name, want, got)
+			t.Errorf("Append_one %q: wanted read %q, got %q", test.name, want, got)
 		}
 	}
 }
 
-func TestReader_Next(t *testing.T) {
+func TestWriter_Append_multiple(t *testing.T) {
+	cases := []struct {
+		name  string
+		write []string
+	}{
+		{
+			name:  "simple",
+			write: []string{"hello", "there", "person"},
+		},
+		{
+			name:  "with delimiters",
+			write: []string{"hello\xfe\xfd", "\xfe\xfdthere", "per\xfe\xfdson", "hey", "mul\xfe\xfdtiple\xfe\xfddelimiters"},
+		},
+	}
+
+	for _, test := range cases {
+		buf := new(bytes.Buffer)
+		w := NewWriter(buf)
+		for _, val := range test.write {
+			if err := w.Append([]byte(val)); err != nil {
+				t.Fatalf("Append_multiple %q: %v", test.name, err)
+			}
+		}
+
+		var got []string
+		r := NewReader(buf)
+		for !r.Done() {
+			b, err := r.Next()
+			if err != nil {
+				t.Fatalf("Append_multiple %q: %v", test.name, err)
+			}
+			got = append(got, string(b))
+		}
+
+		if diff := cmp.Diff(test.write, got); diff != "" {
+			t.Errorf("Append_multiple: %q unexpected diff (+got -want):\n%v", test.name, diff)
+		}
+	}
+}
+
+func TestReader_Next_corrupt(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want []string // empty means "expect a corruption error" for this test sequence
+	}{
+		{
+			name: "missing-delimiter",
+			raw:  "hello",
+			want: []string{""},
+		},
+	}
+
+	for _, test := range cases {
+		buf := bytes.NewBuffer([]byte(test.raw))
+		r := NewReader(buf)
+		for i, want := range test.want {
+			b, err := r.Next()
+			if err != nil {
+				switch {
+				case want == "" && errors.Is(err, CorruptRecord):
+					// do nothing, this is fine
+				case want == "" && !errors.Is(err, CorruptRecord):
+					t.Fatalf("Next_corrupt %q: expected corruption error, got %v with value %q", test.name, err, string(b))
+				default:
+					t.Fatalf("Next_corrupt %q: %v", test.name, err)
+				}
+			}
+			if diff := cmp.Diff(string(b), want); diff != "" {
+				t.Errorf("Next_corrupt %q: unexpected diff in record %d:\n%v", test.name, i, diff)
+			}
+		}
+	}
 }

--- a/pkg/stuffedio/stuffedio_test.go
+++ b/pkg/stuffedio/stuffedio_test.go
@@ -1,0 +1,73 @@
+package stuffedio
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"testing"
+)
+
+func Example() {
+	buf := new(bytes.Buffer)
+
+	w := NewWriter(buf)
+	if err := w.Append([]byte("A very short message")); err != nil {
+		log.Fatalf("Error appending: %v", err)
+	}
+
+	fmt.Printf("%q\n", string(buf.Bytes()))
+
+	r := NewReader(buf)
+	for !r.Done() {
+		b, err := r.Next()
+		if err != nil {
+			log.Fatalf("Error reading: %v", err)
+		}
+		fmt.Println(string(b))
+	}
+
+	// Output:
+	// "\xfe\xfd\x14A very short message"
+	// A very short message
+}
+
+func TestWriter_Append_short(t *testing.T) {
+	cases := []struct {
+		name  string
+		write string
+		raw   string
+		want  string
+	}{
+		{
+			name:  "simple",
+			write: "Short message",
+			raw:   "\xfe\xfd\x0dShort message",
+			want:  "Short message",
+		},
+		{
+			name:  "with-delimiters",
+			write: "short\xfe\xfd",
+			raw:   "\xfe\xfd\x05short",
+			want:  "short\xfe\xfd",
+		},
+	}
+
+	for _, test := range cases {
+		buf := new(bytes.Buffer)
+		w := NewWriter(buf)
+		if err := w.Append([]byte(test.write)); err != nil {
+			t.Fatalf("Append_short %q: writing: %v", test.name, err)
+		}
+		if want, got := []byte(test.raw), buf.Bytes(); !bytes.Equal(want, got) {
+			t.Fatalf("Append_short %q: want raw %q, got %q", test.name, string(want), string(got))
+		}
+		r := NewReader(buf)
+		b, err := r.Next()
+		if err != nil {
+			t.Fatalf("Append_short %q: reading: %v", test.name, err)
+		}
+		if want, got := test.want, string(b); want != got {
+			t.Errorf("Append_short %q: wanted read %q, got %q", test.name, want, got)
+		}
+	}
+}

--- a/pkg/wal/wal.go
+++ b/pkg/wal/wal.go
@@ -1,0 +1,298 @@
+// Package wal implements a straightforward write-ahead log using
+// consistent-overhead byte stuffing as described in
+// https://www.pvk.ca/Blog/2021/01/11/stuff-your-logs/.
+package wal
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+)
+
+const (
+	reserved   = [2]byte{0xfe, 0xfd}
+	radix      = 0xfd
+	smallLimit = 0xfc
+	largeLimit = 0xfcfc
+)
+
+var (
+	ShortRead = fmt.Errorf("short read")
+)
+
+// RecWriter wraps an underlying writer and appends records to the stream when
+// requested, encoding them using constant-overhead word stuffing.
+type RecWriter struct {
+	dest io.Writer
+}
+
+func isDelimiter(b []byte, pos int) bool {
+	if pos > len(b)-len(reserved) {
+		return false
+	}
+	return bytes.Equal(b[pos:pos+len(reserved)], reserved[:])
+}
+
+func findReserved(p []byte, end int) (end int, found bool) {
+	if end > len(p) {
+		end = len(p)
+	}
+	if end < len(reserved) {
+		return end, false
+	}
+	// Check up to the penultimate position (two-byte check).
+	for i := start; i < end-len(reserved)+1; i++ {
+		if isDelimiter(p, i) {
+			return i, true
+		}
+	}
+	return end, false
+}
+
+// Append adds a record to the end of the underlying writer. It encodes it
+// using word stuffing.
+func (w *RecWriter) Append(p []byte) error {
+	if len(p) == 0 {
+		return nil
+	}
+
+	// Always start with the delimiter.
+	buf := bytes.NewBuffer(reserved[:])
+
+	// First block is small, try to find the reserved sequence in the first smallLimit bytes.
+	// Format that block as |reserved 0|reserved 1|length|actual bytes...|.
+	// Note that nowhere in these bytes can the reserved sequence fully appear (by construction).
+	end, foundReserved := findReserved(p, smallLimit)
+
+	// Add the size and data.
+	if _, err := buf.Write(append(make([]byte, 0, 1+end), byte(end), p[:end]...)); err != nil {
+		return fmt.Errorf("write rec: %w", err)
+	}
+
+	// Set the starting point for the next rounds. If we found a delimiter, we
+	// need to advance past it first.
+	if foundReserved {
+		end += len(reserved)
+	}
+
+	// The next blocks are larger, up to largeLimit bytes each. Find the
+	// reserved sequence if it's in there.
+	// Format each block as |len1|len2|actual bytes...|.
+
+	p = p[end:]
+	for len(p) != 0 {
+		end, foundReserved = findReserved(p, largeLimit)
+		// Little-Endian length.
+		len1 := (end - start) % radix
+		len2 := (end - start) / radix
+		if _, err := buf.Write(append(make([]byte, 0, 2+end), byte(len1), byte(len2), p[:end]...)); err != nil {
+			return fmt.Errorf("write rec: %w", err)
+		}
+
+		if foundReserved {
+			end += 2
+		}
+		p = p[end:]
+	}
+	if _, err := io.Copy(w.dest, buf); err != nil {
+		return fmt.Errorf("write rec: %w", err)
+	}
+	return nil
+}
+
+// RecReader wraps an io.Reader and allows full records to be pulled at once.
+type RecReader struct {
+	src   io.Reader
+	buf   []byte
+	pos   int  // position in the unused read buffer.
+	end   int  // one past the end of unused data.
+	ended bool // EOF reached, don't read again.
+}
+
+// NewRecReader creates a RecReader from the given src, which is assumed to be
+// a word-stuffed log.
+func NewRecReader(src io.Reader) *RecReader {
+	return &RecReader{
+		src: src,
+		buf: make([]byte, 1<<17),
+	}
+}
+
+// fillBuf ensures that the internal buffer is at least half full, which is
+// enough space for one short read and one long read.
+func (r *RecReader) fillBuf() error {
+	if r.ended {
+		return nil // just use pos/end, no more reading.
+	}
+	if r.end-r.pos >= len(buf)/2 {
+		// Don't bother filling if it's at least half full.
+		// The buffer is designed to
+		return nil
+	}
+	// Room to move, shift left.
+	if r.pos != 0 {
+		copy(r.buf[:], r.buf[r.pos:r.end])
+	}
+	r.end -= r.pos
+	r.pos = 0
+
+	// Read as much as possible.
+	n, err := r.src.Read(r.buf[r.end:])
+	if err != nil {
+		if err != io.EOF {
+			return fmt.Errorf("fill buffer: %w", err)
+		}
+		r.ended = true
+	}
+	r.end += n
+	return nil
+}
+
+// consumeLeader advances the position of the buffer, only if it contains a leading delimiter.
+func (r *RecReader) consumeLeader() bool {
+	if r.end-r.pos < len(reserved) {
+		return false
+	}
+	if bytes.Equal(r.buf[r.pos:r.pos+len(reserved)], reserved[:]) {
+		r.pos += 2
+		return true
+	}
+	return false
+}
+
+// pullN gets the next n bytes from the buffer, consuing it. The buffer must
+// already have at least that many bytes, or it will return an error. It does
+// not trigger a read.
+func (r *RecReader) pullN(n int) ([]byte, error) {
+	// Get the next n values from the buffer, consuming it.
+	if want, have := n, r.end-r.pos; want > have {
+		return nil, fmt.Errorf("pull n: want %d bytes, only have %d", want, have)
+	}
+	start := r.pos
+	r.pos += n
+	return r.buf[start:r.pos], nil
+}
+
+func (r *RecReader) isDelimiter(pos int) bool {
+	return isDelimiter(r.buf[:r.end], pos)
+}
+
+// Done indicates whether the underlying stream is exhausted and all records are returned.
+func (r *RecReader) Done() bool {
+	return r.end == r.pos && r.ended
+}
+
+// scanN returns at most the next n bytes, fewer if it hits the end or a delimiter.
+// It conumes them from the buffer. It does not read from the source: ensure
+// that the buffer is full enough to proceed before calling. It can only go up
+// to the penultimate byte, to ensure that it doesn't read half a delimiter.
+func (r *RecReader) scanN(n int) ([]byte, error) {
+	start := r.pos
+	maxEnd := r.end - len(reserved) + 1
+	// Ensure that we don't go beyond the end of the buffer (minus 1). The
+	// caller should never ask for more than this. But it can happen if, for
+	// example, the underlying stream is exhausted on a final block, with only
+	// the implicit delimiter.
+	if have := maxEnd - r.pos; n > have {
+		if !r.ended {
+			return nil, fmt.Errorf("scan: asked for %d, only had %d to read on in-progress buffer", n, have)
+		}
+		n = have
+	}
+	if maxEnd > start+n {
+		maxEnd = start + n
+	}
+	for r.pos < maxEnd {
+		if r.isDelimiter(r.pos) {
+			break
+		}
+		r.pos++
+	}
+	return r.buf[start:r.pos], nil
+}
+
+// Next returns the next record in the underying stream.
+func (r *RecReader) Next() ([]byte, error) {
+	if r.Done() {
+		return nil, io.EOF
+	}
+	buf := new(bytes.Buffer)
+	if err := r.fillBuf(); err != nil {
+		return nil, fmt.Errorf("next: %w", err)
+	}
+	// Read the first (small) section.
+	r.consumeLeader()
+	b, err := r.pullN(1)
+	if err != nil {
+		return nil, fmt.Errorf("next: %w", err)
+	}
+	smallSize := int(b[0])
+	if smallSize > smallLimit {
+		return nil, fmt.Errorf("next: short size header %d is too large", smallSize)
+	}
+	// The size portion can't be part of a delimiter, because it would have
+	// triggered a "too big" error. Now we scan for delimiters while reading
+	// from the buffer. Technically, when everything goes well, we should
+	// always read exactly the right number of bytes. But the point of this is
+	// that sometimes a record will be corrupted, so we might encounter a
+	// delimiter in an unexpected place, so we scan and then check the size of
+	// the return value. It can be wrong. In that case, return a meaingful
+	// error so the caller can decide whether to keep going with the next
+	// record.
+	b, err := r.scanN(smallSize)
+	if err != nil {
+		return nil, fmt.Errorf("next: %w", err)
+	}
+	if len(b) != smallSize {
+		return nil, fmt.Errorf("next wanted %d, got %d: %w", smallSize, len(b), ShortRead)
+	}
+
+	if _, err := buf.Write(b); err != nil {
+		return nil, fmt.Errorf("next: %w", err)
+	}
+	if smallSize != smallLimit {
+		// Implied delimiter in the data itself. Write the reserved word.
+		if _, err := buf.Write(reserved[:]); err != nil {
+			return nil, fmt.Errorf("next: %w", err)
+		}
+	}
+
+	// Now we read zero or more large sections, stopping when we hit a delimiter or the end of the input stream.
+	for !r.isDelimiter(r.pos) && !r.Done() {
+		if err := r.fillBuf(); err != nil {
+			return nil, fmt.Errorf("next: %w", err)
+		}
+		// Extract 2 size bytes, convert using the radix.
+		b, err := r.pullN(2)
+		if err != nil {
+			return nil, fmt.Errorf("next: %w", err)
+		}
+		if b[0] >= radix || b[1] >= radix {
+			return nil, fmt.Errorf("next: one of the two size bytes has an invalid value: %x", b[0])
+		}
+		size := int(b[0]) + radix*int(b[1]) // little endian size, in radix base.
+		if size > largeLimit {
+			return nil, fmt.Errorf("next: large interior size %d", size)
+		}
+		b, err := r.scanN(size)
+		if err != nil {
+			return nil, fmt.Errorf("next: %w", err)
+		}
+		if len(b) != size {
+			return nil, fmt.Errorf("next wanted %d, got %d: %w", size, len(b), ShortRead)
+		}
+		if _, err := buf.Write(b); err != nil {
+			return nil, fmt.Errorf("next: %w", err)
+		}
+		if size != largeLimit {
+			// Implied delimiter in the data itself, append.
+			if _, err := buf.Write(reserved[:]); err != nil {
+				return nil, fmt.Errorf("next: %w", err)
+			}
+		}
+	}
+
+	// Note: the last block will always have an extra delimiter appended to the
+	// end of it, so we have to not return that part.
+	return buf.Bytes()[:buf.Len()-len(reserved)]
+}


### PR DESCRIPTION
This change implements the `stuffedio` package, which can be used to create a write-ahead log. It's the foundation of all such logging, and can be used to implement a journal for the in-memory implementation later on.