### PR TITLE
fix: added database parameter to connStr

### DIFF
--- a/backend/eqpg/pg.go
+++ b/backend/eqpg/pg.go
@@ -158,6 +158,7 @@ func Opener(hostPort string, opts ...PGOpt) entroq.BackendOpener {
 
 		params := []string{
 			"sslmode=" + string(options.sslMode),
+			"database=" + options.db,
 		}
 
 		if options.user != "" {

--- a/backend/eqpg/pg.go
+++ b/backend/eqpg/pg.go
@@ -158,7 +158,7 @@ func Opener(hostPort string, opts ...PGOpt) entroq.BackendOpener {
 
 		params := []string{
 			"sslmode=" + string(options.sslMode),
-			"database=" + options.db,
+			"database=" + escp(options.db),
 		}
 
 		if options.user != "" {


### PR DESCRIPTION
By default `options.db` is ignored!
Therefore, when I pass the option `WithDB("xxx")` it is ignored.

I've added `"database=" + options.db` to be always passed on to connStr