### PR TITLE
feat(eqlink): add `push`, the source-side mirror of `pull`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **`eqlink push`.** The mirror of `eqlink pull`: claims from a local queue and
+  delivers into a remote instance's inbox, exactly once, over the same
+  `pullworker` engine. Runs next to the source (leaf), for hub-and-spoke fan-in.
+  The dedup tombstone lives on the remote destination, so its cleanup crosses the
+  wire; `--source-name` must be unique per source instance to avoid collisions on
+  the shared destination.
+
+---
+
 ## [1.3.0] - 2026-07-01
 
 Go module `v1.3.0`. Adds exactly-once cross-instance task handoff (`eqlink pull`).

--- a/cmd/eqlink/cmd/push.go
+++ b/cmd/eqlink/cmd/push.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/shiblon/entroq"
+	"github.com/shiblon/entroq/pkg/backend/eqgrpc"
+	"github.com/shiblon/entroq/pkg/worker"
+	"github.com/shiblon/entroq/pkg/workers/pullworker"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+var (
+	destEntroqAddr   string
+	destCertFile     string
+	destKeyFile      string
+	destCAFile       string
+	pushSourceQueues []string
+	pushInbox        string
+	pushTTL          time.Duration
+	pushSourceName   string
+	pushConcurrency  int
+)
+
+var pushCmd = &cobra.Command{
+	Use:   "push",
+	Short: "Push tasks from a local queue into a remote EntroQ instance's inbox, exactly once.",
+	Long: `Claims tasks from --source-queue on the local instance (--entroq) and delivers
+them into --inbox on a remote EntroQ instance (--dest-entroq), exactly once in
+effect. This is the mirror of "eqlink pull": same handoff, but run next to the
+SOURCE. Use it for hub-and-spoke fan-in, where each leaf pushes its work up to a
+central instance.
+
+The dedup tombstone is created on the destination, so with push it lives on the
+remote instance: eager cleanup and the tombstone reaper cross the wire. That is
+the inherent cost of running next to the source rather than the destination; for
+a busy fan-in you may prefer to run a single reaper next to the hub instead of
+relying on each leaf's remote reaping.
+
+--source-name MUST be unique per source instance. It is mixed into the
+deterministic transfer id; if two leaves share a name, their tasks can collide on
+the shared destination and one leaf's work would be silently dropped as a
+duplicate. Use the tenant id, host id, or similar stable unique value.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Cancel on SIGINT/SIGTERM: workers stop claiming and exit cleanly. An
+		// interrupted in-flight delivery is safe -- the source task's lease keeps
+		// it, and the next claim re-delivers idempotently (the tombstone dedups).
+		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
+
+		// Local (source) instance: where tasks are claimed from.
+		src, err := entroq.New(ctx, eqgrpc.Opener(entroqAddr, eqgrpc.WithInsecure()))
+		if err != nil {
+			return fmt.Errorf("source entroq: %w", err)
+		}
+		defer src.Close()
+
+		// Remote (destination) instance: where tasks are delivered.
+		destTLS, err := loadTLSConfig(destCertFile, destKeyFile, destCAFile)
+		if err != nil {
+			return fmt.Errorf("dest tls: %w", err)
+		}
+		var destOpts []eqgrpc.Option
+		if destTLS != nil {
+			destOpts = append(destOpts, eqgrpc.WithDialOpts(grpc.WithTransportCredentials(credentials.NewTLS(destTLS))))
+		} else {
+			destOpts = append(destOpts, eqgrpc.WithInsecure())
+		}
+		dst, err := entroq.New(ctx, eqgrpc.Opener(destEntroqAddr, destOpts...))
+		if err != nil {
+			return fmt.Errorf("dest entroq: %w", err)
+		}
+		defer dst.Close()
+
+		g, gCtx := errgroup.WithContext(ctx)
+
+		// Push workers: claim from the local source, deliver into the remote inbox.
+		for range pushConcurrency {
+			g.Go(func() error {
+				return pullworker.Run(gCtx, src,
+					pullworker.WithDest(dst),
+					pullworker.WithInbox(pushInbox),
+					pullworker.WithQueues(pushSourceQueues...),
+					pullworker.WithTTL(pushTTL),
+					pullworker.WithSource(pushSourceName),
+				)
+			})
+		}
+
+		// Reaper: delete spent tombstones from the remote instance once due. This
+		// crosses the wire; see the note about a hub-side reaper for busy fan-in.
+		g.Go(func() error {
+			reaper := worker.New(dst, worker.WithDoModify(
+				func(_ context.Context, t *entroq.Task, _ json.RawMessage, _ []*entroq.Doc) ([]entroq.ModifyArg, error) {
+					return []entroq.ModifyArg{t.Delete()}, nil
+				}))
+			return reaper.Run(gCtx, worker.Watching(pullworker.TombstoneQueue(pushInbox)))
+		})
+
+		return g.Wait()
+	},
+}
+
+func init() {
+	flags := pushCmd.Flags()
+	flags.StringVar(&destEntroqAddr, "dest-entroq", "", "Remote destination EntroQ gRPC address to deliver to (required).")
+	flags.StringVar(&destCertFile, "dest-cert", "", "TLS certificate for the destination connection.")
+	flags.StringVar(&destKeyFile, "dest-key", "", "TLS private key for the destination connection.")
+	flags.StringVar(&destCAFile, "dest-ca", "", "CA bundle for verifying the destination peer.")
+	flags.StringSliceVar(&pushSourceQueues, "source-queue", nil, "Local queue(s) to claim tasks from (required, repeatable).")
+	flags.StringVar(&pushInbox, "inbox", "", "Remote destination inbox queue (required).")
+	flags.DurationVar(&pushTTL, "ttl", pullworker.DefaultTTL, "Tombstone retention window; must exceed worst-case recovery time.")
+	flags.StringVar(&pushSourceName, "source-name", "", "Stable identifier for this source instance, unique across all pushers to the same destination (required).")
+	flags.IntVar(&pushConcurrency, "concurrency", 1, "Number of concurrent push workers.")
+
+	pushCmd.MarkFlagRequired("dest-entroq")
+	pushCmd.MarkFlagRequired("source-queue")
+	pushCmd.MarkFlagRequired("inbox")
+	pushCmd.MarkFlagRequired("source-name")
+
+	rootCmd.AddCommand(pushCmd)
+}

--- a/cmd/eqlink/cmd/root.go
+++ b/cmd/eqlink/cmd/root.go
@@ -30,8 +30,9 @@ The sender proxies outgoing HTTP calls from the local service into queues.
 The receiver claims tasks from queues and forwards them to the local service.
 The GC cleans up stale response queues left by crashed senders.
 
-The pull command links two EntroQ instances directly, moving tasks from a queue
-on a remote instance into a local inbox exactly once.`,
+The pull and push commands link two EntroQ instances directly, moving tasks
+between them exactly once: pull claims from a remote instance into a local inbox;
+push claims from a local queue into a remote inbox.`,
 }
 
 // Execute is the entry point called from main.

--- a/cmd/eqlink/main.go
+++ b/cmd/eqlink/main.go
@@ -6,8 +6,9 @@
 // Individual components can be run separately with "eqlink send", "eqlink recv",
 // and "eqlink gc".
 //
-// "eqlink pull" is a separate mode that links two EntroQ instances directly,
-// moving tasks from a queue on a remote instance into a local inbox exactly once.
+// "eqlink pull" and "eqlink push" link two EntroQ instances directly, moving
+// tasks between them exactly once (pull claims from a remote instance into a
+// local inbox; push claims from a local queue into a remote inbox).
 package main
 
 import "github.com/shiblon/entroq/cmd/eqlink/cmd"


### PR DESCRIPTION
## Summary

Adds `eqlink push` — the mirror of `eqlink pull`. It claims from a **local** queue and delivers into a **remote** instance's inbox, exactly once in effect, over the same `pullworker` engine (only which side is local differs; the command just wires `src = local`, `dst = remote`).

Run it next to the **source** (leaf), for hub-and-spoke **fan-in**: each leaf pushes its work up to a central instance. (`pull` is the same handoff run next to the destination.)

## Notes

- **Tombstone locality.** The dedup tombstone is created on the destination, so with `push` it lives on the remote instance — eager cleanup and the reaper cross the wire. That's the inherent cost of running next to the source; for a busy fan-in you may prefer a single reaper next to the hub over each leaf's remote reaping.
- **`--source-name` is required and must be unique per source instance.** It's mixed into the deterministic transfer id; a shared name would let two leaves' tasks collide on the shared destination and silently drop one as a duplicate.

## Testing

Same engine as `pull` (already tested for delivery + no-duplicate-on-redelivery). `go build ./...`, `go vet`, and `eqlink push --help` verified.

Targets **v1.4.0** (minor).