### PR TITLE
fix(eqlink): secure the local connection for pull and push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   honors `--cert`/`--key`/`--ca` (TLS) and `--authz-token-file` (bearer token,
   reloaded on rotation as `run` already does). Fixes #73. The token-reload logic
   is now shared across `run`, `pull`, and `push` via a new internal helper.
+- **Remote TLS inherits the local `--cert`/`--key`/`--ca`** when a `pull`/`push`
+  invocation sets none of its `--source-*`/`--dest-*` flags (logged). A single
+  trust domain then needs the certs given only once; distinct trust domains still
+  set their own per-connection flags. This also removes a footgun: an unset
+  remote is no longer silently insecure.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **`eqlink pull` and `push` can now secure the local connection.** The local
+  (`--entroq`) connection previously ignored transport security and auth; it now
+  honors `--cert`/`--key`/`--ca` (TLS) and `--authz-token-file` (bearer token,
+  reloaded on rotation as `run` already does). Fixes #73. The token-reload logic
+  is now shared across `run`, `pull`, and `push` via a new internal helper.
+
+---
+
 ## [1.4.0] - 2026-07-01
 
 Go module `v1.4.0`. Adds `eqlink push`, the source-side mirror of `pull`.

--- a/cmd/eqlink/cmd/conn.go
+++ b/cmd/eqlink/cmd/conn.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/shiblon/entroq"
+	"github.com/shiblon/entroq/pkg/backend/eqgrpc"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// localEQ opens the local EntroQ instance (--entroq) with optional transport
+// security (--cert/--key/--ca) and bearer-token auth (--authz-token-file). When
+// a token file is given, the token is reloaded on rotation (SIGHUP or mtime
+// change) by a goroutine spawned on g, and the token's subject becomes the
+// client's claimant.
+//
+// It exists so that "eqlink pull" and "eqlink push" can reach a secured local
+// instance, not only an insecure loopback one.
+func localEQ(ctx context.Context, g *errgroup.Group) (*entroq.EntroQ, error) {
+	tlsCfg, err := loadTLSConfig(certFile, keyFile, caFile)
+	if err != nil {
+		return nil, fmt.Errorf("local tls: %w", err)
+	}
+	var opts []eqgrpc.Option
+	if tlsCfg != nil {
+		opts = append(opts, eqgrpc.WithDialOpts(grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg))))
+	} else {
+		opts = append(opts, eqgrpc.WithInsecure())
+	}
+
+	var eqOpts []entroq.Option
+	if authzTokenFile != "" {
+		creds, err := newTokenFileCreds(authzTokenFile)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, eqgrpc.WithDialOpts(grpc.WithPerRPCCredentials(creds)))
+		eqOpts = append(eqOpts, entroq.WithClaimantID(creds.claimant))
+		watchTokenReload(ctx, g, creds)
+	}
+
+	eq, err := entroq.New(ctx, eqgrpc.Opener(entroqAddr, opts...), eqOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("local entroq: %w", err)
+	}
+	return eq, nil
+}
+
+// tokenFileCreds implements grpc.PerRPCCredentials with an in-memory bearer
+// token that is loaded at startup and reloaded on rotation.
+type tokenFileCreds struct {
+	path     string
+	claimant string // sub#nonce, computed once at startup
+	token    atomic.Pointer[string]
+}
+
+// newTokenFileCreds loads the token immediately; returns an error if the file
+// cannot be read.
+func newTokenFileCreds(path string) (*tokenFileCreds, error) {
+	c := &tokenFileCreds{path: path}
+	if err := c.reload(); err != nil {
+		return nil, err
+	}
+	c.claimant = entroq.MustClaimantFromSub(*c.token.Load())
+	return c, nil
+}
+
+func (c *tokenFileCreds) reload() error {
+	data, err := os.ReadFile(c.path)
+	if err != nil {
+		return fmt.Errorf("bearer token file %q: %w", c.path, err)
+	}
+	tok := strings.TrimSpace(string(data))
+	c.token.Store(&tok)
+	return nil
+}
+
+func (c *tokenFileCreds) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	return map[string]string{"authorization": "Bearer " + *c.token.Load()}, nil
+}
+
+func (*tokenFileCreds) RequireTransportSecurity() bool {
+	return false
+}
+
+// watchTokenReload spawns a goroutine on g that reloads creds when its token
+// file changes -- on SIGHUP, or when the file's mtime advances (polled at
+// tokenReloadInterval). k8s projected tokens are rotated by the kubelet by
+// rewriting the file. The goroutine returns when ctx is done.
+func watchTokenReload(ctx context.Context, g *errgroup.Group, creds *tokenFileCreds) {
+	interval := tokenReloadInterval
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	hupsigs := make(chan os.Signal, 1)
+	signal.Notify(hupsigs, syscall.SIGHUP)
+	g.Go(func() error {
+		defer signal.Stop(hupsigs)
+		info, _ := os.Stat(creds.path)
+		var lastMtime time.Time
+		if info != nil {
+			lastMtime = info.ModTime()
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-hupsigs:
+				if err := creds.reload(); err != nil {
+					log.Printf("token reload (SIGHUP): %v", err)
+				} else {
+					log.Printf("token reloaded (SIGHUP) from %s", creds.path)
+				}
+			case <-ticker.C:
+				fi, err := os.Stat(creds.path)
+				if err != nil {
+					log.Printf("token stat %s: %v", creds.path, err)
+					continue
+				}
+				if fi.ModTime().After(lastMtime) {
+					lastMtime = fi.ModTime()
+					if err := creds.reload(); err != nil {
+						log.Printf("token reload (stat): %v", err)
+					} else {
+						log.Printf("token reloaded (stat) from %s", creds.path)
+					}
+				}
+			}
+		}
+	})
+}

--- a/cmd/eqlink/cmd/conn.go
+++ b/cmd/eqlink/cmd/conn.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log"
 	"os"
@@ -54,6 +55,24 @@ func localEQ(ctx context.Context, g *errgroup.Group) (*entroq.EntroQ, error) {
 		return nil, fmt.Errorf("local entroq: %w", err)
 	}
 	return eq, nil
+}
+
+// remoteTLS builds the TLS config for a remote connection (label names it, e.g.
+// "source" or "dest"). When none of the remote's cert/key/ca are set, it
+// inherits the local --cert/--key/--ca -- a convenience for the common
+// single-trust-domain case, where the flags would otherwise be repeated. This
+// only ever makes the remote MORE secure (an unset remote is otherwise
+// insecure); if the remote lives in a distinct trust domain, set its own
+// --<label>-cert/key/ca and no fallback happens. The fallback is logged so it's
+// never a surprise.
+func remoteTLS(label, cert, key, ca string) (*tls.Config, error) {
+	if cert == "" && key == "" && ca == "" {
+		if certFile != "" || keyFile != "" || caFile != "" {
+			log.Printf("%s: no --%s-cert/--%s-key/--%s-ca set; inheriting local --cert/--key/--ca", label, label, label, label)
+		}
+		return loadTLSConfig(certFile, keyFile, caFile)
+	}
+	return loadTLSConfig(cert, key, ca)
 }
 
 // tokenFileCreds implements grpc.PerRPCCredentials with an in-memory bearer

--- a/cmd/eqlink/cmd/pull.go
+++ b/cmd/eqlink/cmd/pull.go
@@ -42,7 +42,10 @@ collides on the tombstone, so no duplicate inbox task is produced.
 Run this next to the destination instance: only the claim from the source crosses
 the wire. A reaper deletes spent tombstones from <inbox>/_tombstone once their TTL
 elapses; the happy path deletes its own tombstone immediately, so the reaper only
-handles crash orphans.`,
+handles crash orphans.
+
+The local (--entroq) connection secures with --cert/--key/--ca and authenticates
+with --authz-token-file; the remote source uses --source-cert/--source-key/--source-ca.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Cancel on SIGINT/SIGTERM: workers stop claiming and exit cleanly. An
 		// interrupted in-flight delivery is safe -- the source task's lease keeps
@@ -50,8 +53,11 @@ handles crash orphans.`,
 		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 		defer stop()
 
-		// Local (destination) instance: where tasks are delivered.
-		dst, err := entroq.New(ctx, eqgrpc.Opener(entroqAddr, eqgrpc.WithInsecure()))
+		g, gCtx := errgroup.WithContext(ctx)
+
+		// Local (destination) instance: where tasks are delivered. Transport
+		// security and auth come from --cert/--key/--ca and --authz-token-file.
+		dst, err := localEQ(gCtx, g)
 		if err != nil {
 			return fmt.Errorf("dest entroq: %w", err)
 		}
@@ -68,7 +74,7 @@ handles crash orphans.`,
 		} else {
 			srcOpts = append(srcOpts, eqgrpc.WithInsecure())
 		}
-		src, err := entroq.New(ctx, eqgrpc.Opener(sourceEntroqAddr, srcOpts...))
+		src, err := entroq.New(gCtx, eqgrpc.Opener(sourceEntroqAddr, srcOpts...))
 		if err != nil {
 			return fmt.Errorf("source entroq: %w", err)
 		}
@@ -78,8 +84,6 @@ handles crash orphans.`,
 		if sourceName == "" {
 			sourceName = sourceEntroqAddr
 		}
-
-		g, gCtx := errgroup.WithContext(ctx)
 
 		// Pull workers: claim from the source, deliver into the local inbox.
 		for range pullConcurrency {

--- a/cmd/eqlink/cmd/pull.go
+++ b/cmd/eqlink/cmd/pull.go
@@ -45,7 +45,8 @@ elapses; the happy path deletes its own tombstone immediately, so the reaper onl
 handles crash orphans.
 
 The local (--entroq) connection secures with --cert/--key/--ca and authenticates
-with --authz-token-file; the remote source uses --source-cert/--source-key/--source-ca.`,
+with --authz-token-file; the remote source uses --source-cert/--source-key/--source-ca,
+falling back to --cert/--key/--ca when none of those are set.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Cancel on SIGINT/SIGTERM: workers stop claiming and exit cleanly. An
 		// interrupted in-flight delivery is safe -- the source task's lease keeps
@@ -63,8 +64,9 @@ with --authz-token-file; the remote source uses --source-cert/--source-key/--sou
 		}
 		defer dst.Close()
 
-		// Remote (source) instance: where tasks are claimed from.
-		srcTLS, err := loadTLSConfig(sourceCertFile, sourceKeyFile, sourceCAFile)
+		// Remote (source) instance: where tasks are claimed from. Its TLS falls
+		// back to the local --cert/--key/--ca when no --source-* flags are set.
+		srcTLS, err := remoteTLS("source", sourceCertFile, sourceKeyFile, sourceCAFile)
 		if err != nil {
 			return fmt.Errorf("source tls: %w", err)
 		}

--- a/cmd/eqlink/cmd/push.go
+++ b/cmd/eqlink/cmd/push.go
@@ -48,7 +48,10 @@ relying on each leaf's remote reaping.
 --source-name MUST be unique per source instance. It is mixed into the
 deterministic transfer id; if two leaves share a name, their tasks can collide on
 the shared destination and one leaf's work would be silently dropped as a
-duplicate. Use the tenant id, host id, or similar stable unique value.`,
+duplicate. Use the tenant id, host id, or similar stable unique value.
+
+The local (--entroq) connection secures with --cert/--key/--ca and authenticates
+with --authz-token-file; the remote destination uses --dest-cert/--dest-key/--dest-ca.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Cancel on SIGINT/SIGTERM: workers stop claiming and exit cleanly. An
 		// interrupted in-flight delivery is safe -- the source task's lease keeps
@@ -56,8 +59,11 @@ duplicate. Use the tenant id, host id, or similar stable unique value.`,
 		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 		defer stop()
 
-		// Local (source) instance: where tasks are claimed from.
-		src, err := entroq.New(ctx, eqgrpc.Opener(entroqAddr, eqgrpc.WithInsecure()))
+		g, gCtx := errgroup.WithContext(ctx)
+
+		// Local (source) instance: where tasks are claimed from. Transport
+		// security and auth come from --cert/--key/--ca and --authz-token-file.
+		src, err := localEQ(gCtx, g)
 		if err != nil {
 			return fmt.Errorf("source entroq: %w", err)
 		}
@@ -74,13 +80,11 @@ duplicate. Use the tenant id, host id, or similar stable unique value.`,
 		} else {
 			destOpts = append(destOpts, eqgrpc.WithInsecure())
 		}
-		dst, err := entroq.New(ctx, eqgrpc.Opener(destEntroqAddr, destOpts...))
+		dst, err := entroq.New(gCtx, eqgrpc.Opener(destEntroqAddr, destOpts...))
 		if err != nil {
 			return fmt.Errorf("dest entroq: %w", err)
 		}
 		defer dst.Close()
-
-		g, gCtx := errgroup.WithContext(ctx)
 
 		// Push workers: claim from the local source, deliver into the remote inbox.
 		for range pushConcurrency {

--- a/cmd/eqlink/cmd/push.go
+++ b/cmd/eqlink/cmd/push.go
@@ -51,7 +51,8 @@ the shared destination and one leaf's work would be silently dropped as a
 duplicate. Use the tenant id, host id, or similar stable unique value.
 
 The local (--entroq) connection secures with --cert/--key/--ca and authenticates
-with --authz-token-file; the remote destination uses --dest-cert/--dest-key/--dest-ca.`,
+with --authz-token-file; the remote destination uses --dest-cert/--dest-key/--dest-ca,
+falling back to --cert/--key/--ca when none of those are set.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Cancel on SIGINT/SIGTERM: workers stop claiming and exit cleanly. An
 		// interrupted in-flight delivery is safe -- the source task's lease keeps
@@ -69,8 +70,9 @@ with --authz-token-file; the remote destination uses --dest-cert/--dest-key/--de
 		}
 		defer src.Close()
 
-		// Remote (destination) instance: where tasks are delivered.
-		destTLS, err := loadTLSConfig(destCertFile, destKeyFile, destCAFile)
+		// Remote (destination) instance: where tasks are delivered. Its TLS falls
+		// back to the local --cert/--key/--ca when no --dest-* flags are set.
+		destTLS, err := remoteTLS("dest", destCertFile, destKeyFile, destCAFile)
 		if err != nil {
 			return fmt.Errorf("dest tls: %w", err)
 		}

--- a/cmd/eqlink/cmd/run.go
+++ b/cmd/eqlink/cmd/run.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -56,10 +54,6 @@ Graceful shutdown on SIGINT/SIGTERM:
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 		defer signal.Stop(sigs)
-
-		hupsigs := make(chan os.Signal, 1)
-		signal.Notify(hupsigs, syscall.SIGHUP)
-		defer signal.Stop(hupsigs)
 
 		_, stopMetrics, err := setupMetrics(ctx)
 		if err != nil {
@@ -143,47 +137,10 @@ Graceful shutdown on SIGINT/SIGTERM:
 			)
 		})
 
-		// Token reload: periodically stat the token file and reload on mtime
-		// change. k8s projected tokens are rotated by the kubelet (typically
-		// at 80% of the 1h TTL) by updating the file; SIGHUP is also accepted
-		// for manual/scripted reloads.
+		// Token reload: reload the bearer token on rotation (SIGHUP or mtime).
 		hupCtx, hupCancel := context.WithCancel(gCtx)
 		if creds != nil {
-			g.Go(func() error {
-				info, _ := os.Stat(authzTokenFile)
-				var lastMtime time.Time
-				if info != nil {
-					lastMtime = info.ModTime()
-				}
-				ticker := time.NewTicker(tokenReloadInterval)
-				defer ticker.Stop()
-				for {
-					select {
-					case <-hupCtx.Done():
-						return nil
-					case <-hupsigs:
-						if err := creds.reload(); err != nil {
-							log.Printf("token reload (SIGHUP): %v", err)
-						} else {
-							log.Printf("token reloaded (SIGHUP) from %s", authzTokenFile)
-						}
-					case <-ticker.C:
-						fi, err := os.Stat(authzTokenFile)
-						if err != nil {
-							log.Printf("token stat %s: %v", authzTokenFile, err)
-							continue
-						}
-						if fi.ModTime().After(lastMtime) {
-							lastMtime = fi.ModTime()
-							if err := creds.reload(); err != nil {
-								log.Printf("token reload (stat): %v", err)
-							} else {
-								log.Printf("token reloaded (stat) from %s", authzTokenFile)
-							}
-						}
-					}
-				}
-			})
+			watchTokenReload(hupCtx, g, creds)
 		}
 
 		// Signal handler: staged shutdown. Also fires when any goroutine fails
@@ -243,41 +200,4 @@ func newAuditLogger() *slog.Logger {
 		return nil
 	}
 	return slog.New(slog.NewJSONHandler(os.Stderr, nil))
-}
-
-// tokenFileCreds implements grpc.PerRPCCredentials with an in-memory token
-// that is loaded once at startup and reloaded on SIGHUP.
-type tokenFileCreds struct {
-	path     string
-	claimant string // sub#nonce, computed once at startup
-	token    atomic.Pointer[string]
-}
-
-// newTokenFileCreds loads the token immediately; returns an error if the file
-// cannot be read.
-func newTokenFileCreds(path string) (*tokenFileCreds, error) {
-	c := &tokenFileCreds{path: path}
-	if err := c.reload(); err != nil {
-		return nil, err
-	}
-	c.claimant = entroq.MustClaimantFromSub(*c.token.Load())
-	return c, nil
-}
-
-func (c *tokenFileCreds) reload() error {
-	data, err := os.ReadFile(c.path)
-	if err != nil {
-		return fmt.Errorf("bearer token file %q: %w", c.path, err)
-	}
-	tok := strings.TrimSpace(string(data))
-	c.token.Store(&tok)
-	return nil
-}
-
-func (c *tokenFileCreds) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
-	return map[string]string{"authorization": "Bearer " + *c.token.Load()}, nil
-}
-
-func (*tokenFileCreds) RequireTransportSecurity() bool {
-	return false
 }


### PR DESCRIPTION
Fixes #73.

`eqlink pull` and `push` hardwired their **local** (`--entroq`) connection to `WithInsecure()` with no auth, so neither could reach a TLS-only or token-authz local instance — every delivery/claim and the reaper would fail at handshake.

## Fix

The local connection now honors the flags `eqlink` already has:
- `--cert`/`--key`/`--ca` for TLS (via `loadTLSConfig`, same as the remote side).
- `--authz-token-file` for a bearer token, **reloaded on rotation** (SIGHUP or mtime), exactly as `run` already does for k8s projected tokens.

## Refactor

Factored `run.go`'s token-file creds + reload loop into a shared `conn.go`:
- `localEQ(ctx, g)` — opens the local instance with TLS + token + claimant.
- `watchTokenReload(ctx, g, creds)` — the shared reload goroutine.

`run`, `pull`, and `push` now share one implementation. `run`'s local EQ stays insecure-by-default (loopback sidecar) and only adopts the shared reload — no behavior change for the released sidecar; `pull`/`push` gain full local TLS + token.

## Testing

`go build ./...`, `go vet ./cmd/eqlink/...`, and `run`/`pull`/`push --help` all pass. Connection wiring, so no new unit tests (matches the existing cmd package).

Targets **v1.4.1** (patch).