### PR TITLE
Built-in server-side garbage collection (gc= convention)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.5.0] - 2026-07-02
+
+Go module `v1.5.0`. Built-in, best-effort garbage collection: EntroQ servers now
+reap queues that opt in by name, so fault-tolerance recipes no longer need a side
+process for cleanup.
+
+### Added
+
+- **Server-side garbage collection.** `eqpg`, `eqmem`, and `eqredis serve` run a
+  background loop that drains any queue whose name carries a `/gc=<timestamp>`
+  component once that time passes, using ordinary claim/delete so it never removes
+  a task a worker holds. On by default; `--no_gc` opts out and `--gc_interval`
+  tunes the scan period (default 1m). Emits OTel metrics (`entroq_gc_deleted_total`,
+  `entroq_gc_errors_total`, `entroq_gc_sweep_duration_seconds`) with Grafana panels.
+  GC lives in the server: a client that talks directly to a backend (notably the
+  direct-to-PostgreSQL, many-clients model with no server in front) gets no
+  built-in GC and must run its own collector -- see the `eqpg` package docs.
+- **`pkg/gc` and `queues.GCActivation`.** A reusable, matcher-scoped collector and
+  the `gc=` naming convention (empty/`0`/Unix-seconds/RFC3339), usable standalone
+  as well as embedded in a server.
+
+### Changed
+
+- **`eqlink run --run-gc` now defaults off.** The server collects garbage, so the
+  sidecar no longer needs its own loop. Enable it only against a server run with
+  `--no_gc`.
+- **Async response queues use `gc=` instead of `exp=`.** One naming convention. The
+  sender bakes its clock-skew grace into the `gc=` timestamp (`--response_grace`),
+  and the collector simply obeys the timestamp it sees.
+- **`eqlink pull`/`push` tombstones are reaped by the destination server's GC.**
+  The dedup tombstone queue now carries a `gc=0` marker, so the built-in server GC
+  collects crash orphans once their TTL elapses. The bespoke sidecar reaper is
+  replaced by an opt-in `--run-gc` on each command: leave it off when the
+  destination server runs GC (the default), set it when it does not (e.g. a
+  direct-to-PostgreSQL destination).
+
+### Removed
+
+- **GC no longer recognizes the `exp=` alias.** Response queues left in flight by a
+  pre-1.5.0 sender will not be collected by the new GC; they are ephemeral, so this
+  is a one-time, low-impact gap during upgrade.
+
+---
+
 ## [1.4.1] - 2026-07-01
 
 Go module `v1.4.1`. Secures the `eqlink pull`/`push` local connection (TLS + token).

--- a/cmd/eqlink/cmd/gc.go
+++ b/cmd/eqlink/cmd/gc.go
@@ -12,16 +12,16 @@ import (
 
 var (
 	gcInterval  time.Duration
-	gcGrace     time.Duration
 	gcQueueRoot string
 )
 
 var gcCmd = &cobra.Command{
 	Use:   "gc",
 	Short: "Run the global GC: cleans up stale response queues left by crashed or removed sidecars.",
-	Long: `Periodically scans for stale response queues (<root>/*/response/exp=<timestamp>/*)
-where the expiry timestamp has passed (plus a grace period), and deletes any
-tasks still in those queues.
+	Long: `Periodically scans queues under the given prefix for a garbage-collection
+directive in the name (a /gc=<timestamp> or legacy /exp=<timestamp> component)
+whose time has passed, and deletes the claimable tasks in them. Async response
+queues (<root>/*/response/exp=<timestamp>) are the primary case.
 
 Run one instance of this command per EntroQ deployment for global coverage.
 Each "eqlink run" sidecar also runs a local GC scoped to its own queue.`,
@@ -34,9 +34,9 @@ Each "eqlink run" sidecar also runs a local GC scoped to its own queue.`,
 		}
 		defer eq.Close()
 
-		return async.RunGCLoop(ctx, eq, gcQueueRoot,
+		return async.RunGCLoop(ctx, eq,
+			async.WithGCMatch(entroq.MatchPrefix(gcQueueRoot)),
 			async.WithGCInterval(gcInterval),
-			async.WithGCGrace(gcGrace),
 		)
 	},
 }
@@ -44,8 +44,7 @@ Each "eqlink run" sidecar also runs a local GC scoped to its own queue.`,
 func init() {
 	flags := gcCmd.Flags()
 	flags.DurationVar(&gcInterval, "interval", 10*time.Minute, "How often to run the GC scan.")
-	flags.DurationVar(&gcGrace, "grace", 15*time.Second, "Extra time after expiry before GC deletes a response queue.")
-	flags.StringVar(&gcQueueRoot, "root", "/", "Queue name prefix root to scan.")
+	flags.StringVar(&gcQueueRoot, "root", "/", "Queue name prefix to scan.")
 
 	rootCmd.AddCommand(gcCmd)
 }

--- a/cmd/eqlink/cmd/gc.go
+++ b/cmd/eqlink/cmd/gc.go
@@ -19,9 +19,9 @@ var gcCmd = &cobra.Command{
 	Use:   "gc",
 	Short: "Run the global GC: cleans up stale response queues left by crashed or removed sidecars.",
 	Long: `Periodically scans queues under the given prefix for a garbage-collection
-directive in the name (a /gc=<timestamp> or legacy /exp=<timestamp> component)
-whose time has passed, and deletes the claimable tasks in them. Async response
-queues (<root>/*/response/exp=<timestamp>) are the primary case.
+directive in the name (a /gc=<timestamp> component) whose time has passed, and
+deletes the claimable tasks in them. Async response queues
+(<root>/*/response/gc=<timestamp>) are the primary case.
 
 Run one instance of this command per EntroQ deployment for global coverage.
 Each "eqlink run" sidecar also runs a local GC scoped to its own queue.`,

--- a/cmd/eqlink/cmd/gc.go
+++ b/cmd/eqlink/cmd/gc.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/shiblon/entroq"
-	"github.com/shiblon/entroq/pkg/async"
 	"github.com/shiblon/entroq/pkg/backend/eqgrpc"
+	"github.com/shiblon/entroq/pkg/gc"
 	"github.com/spf13/cobra"
 )
 
@@ -34,9 +34,9 @@ Each "eqlink run" sidecar also runs a local GC scoped to its own queue.`,
 		}
 		defer eq.Close()
 
-		return async.RunGCLoop(ctx, eq,
-			async.WithGCMatch(entroq.MatchPrefix(gcQueueRoot)),
-			async.WithGCInterval(gcInterval),
+		return gc.RunLoop(ctx, eq,
+			gc.WithMatch(entroq.MatchPrefix(gcQueueRoot)),
+			gc.WithInterval(gcInterval),
 		)
 	},
 }

--- a/cmd/eqlink/cmd/pull.go
+++ b/cmd/eqlink/cmd/pull.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"os/signal"
 	"syscall"
@@ -10,7 +8,7 @@ import (
 
 	"github.com/shiblon/entroq"
 	"github.com/shiblon/entroq/pkg/backend/eqgrpc"
-	"github.com/shiblon/entroq/pkg/worker"
+	"github.com/shiblon/entroq/pkg/gc"
 	"github.com/shiblon/entroq/pkg/workers/pullworker"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -28,6 +26,7 @@ var (
 	pullTTL          time.Duration
 	pullSourceName   string
 	pullConcurrency  int
+	pullRunGC        bool
 )
 
 var pullCmd = &cobra.Command{
@@ -40,9 +39,11 @@ the local instance, then deletes the source task. A crash that re-delivers
 collides on the tombstone, so no duplicate inbox task is produced.
 
 Run this next to the destination instance: only the claim from the source crosses
-the wire. A reaper deletes spent tombstones from <inbox>/_tombstone once their TTL
-elapses; the happy path deletes its own tombstone immediately, so the reaper only
-handles crash orphans.
+the wire. Spent tombstones are reaped by the destination server's built-in GC once
+their TTL elapses (the tombstone queue carries a gc= marker); the happy path
+deletes its own tombstone immediately, so GC only handles crash orphans. This
+requires the destination server to run GC, which is the default; if it does not
+(e.g. a direct-to-PostgreSQL instance), pass --run-gc to reap tombstones locally.
 
 The local (--entroq) connection secures with --cert/--key/--ca and authenticates
 with --authz-token-file; the remote source uses --source-cert/--source-key/--source-ca,
@@ -100,14 +101,13 @@ falling back to --cert/--key/--ca when none of those are set.`,
 			})
 		}
 
-		// Reaper: delete spent tombstones from the local instance once due.
-		g.Go(func() error {
-			reaper := worker.New(dst, worker.WithDoModify(
-				func(_ context.Context, t *entroq.Task, _ json.RawMessage, _ []*entroq.Doc) ([]entroq.ModifyArg, error) {
-					return []entroq.ModifyArg{t.Delete()}, nil
-				}))
-			return reaper.Run(gCtx, worker.Watching(pullworker.TombstoneQueue(pullInbox)))
-		})
+		if pullRunGC {
+			// Fallback for a destination without built-in GC (e.g. a direct-to-
+			// PostgreSQL instance): reap this inbox's tombstones locally.
+			g.Go(func() error {
+				return gc.RunLoop(gCtx, dst, gc.WithMatch(entroq.MatchExact(pullworker.TombstoneQueue(pullInbox))))
+			})
+		}
 
 		return g.Wait()
 	},
@@ -124,6 +124,7 @@ func init() {
 	flags.DurationVar(&pullTTL, "ttl", pullworker.DefaultTTL, "Tombstone retention window; must exceed worst-case recovery time.")
 	flags.StringVar(&pullSourceName, "source-name", "", "Stable source identifier mixed into the transfer ID (defaults to --source-entroq).")
 	flags.IntVar(&pullConcurrency, "concurrency", 1, "Number of concurrent pull workers.")
+	flags.BoolVar(&pullRunGC, "run-gc", false, "Reap this inbox's dedup tombstones with a local GC loop. Off by default: the destination server collects them. Enable when the destination has no built-in GC (e.g. a direct-to-PostgreSQL instance, or a server run with --no_gc).")
 
 	pullCmd.MarkFlagRequired("source-entroq")
 	pullCmd.MarkFlagRequired("source-queue")

--- a/cmd/eqlink/cmd/push.go
+++ b/cmd/eqlink/cmd/push.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"os/signal"
 	"syscall"
@@ -10,7 +8,7 @@ import (
 
 	"github.com/shiblon/entroq"
 	"github.com/shiblon/entroq/pkg/backend/eqgrpc"
-	"github.com/shiblon/entroq/pkg/worker"
+	"github.com/shiblon/entroq/pkg/gc"
 	"github.com/shiblon/entroq/pkg/workers/pullworker"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -28,6 +26,7 @@ var (
 	pushTTL          time.Duration
 	pushSourceName   string
 	pushConcurrency  int
+	pushRunGC        bool
 )
 
 var pushCmd = &cobra.Command{
@@ -40,10 +39,11 @@ SOURCE. Use it for hub-and-spoke fan-in, where each leaf pushes its work up to a
 central instance.
 
 The dedup tombstone is created on the destination, so with push it lives on the
-remote instance: eager cleanup and the tombstone reaper cross the wire. That is
-the inherent cost of running next to the source rather than the destination; for
-a busy fan-in you may prefer to run a single reaper next to the hub instead of
-relying on each leaf's remote reaping.
+remote instance: its eager cleanup crosses the wire, and its crash orphans are
+reaped by the remote server's built-in GC (the tombstone queue carries a gc=
+marker), not by this process. This requires the remote destination server to run
+GC, which is the default; if it does not (e.g. a direct-to-PostgreSQL instance),
+pass --run-gc to reap tombstones from here across the wire.
 
 --source-name MUST be unique per source instance. It is mixed into the
 deterministic transfer id; if two leaves share a name, their tasks can collide on
@@ -101,15 +101,13 @@ falling back to --cert/--key/--ca when none of those are set.`,
 			})
 		}
 
-		// Reaper: delete spent tombstones from the remote instance once due. This
-		// crosses the wire; see the note about a hub-side reaper for busy fan-in.
-		g.Go(func() error {
-			reaper := worker.New(dst, worker.WithDoModify(
-				func(_ context.Context, t *entroq.Task, _ json.RawMessage, _ []*entroq.Doc) ([]entroq.ModifyArg, error) {
-					return []entroq.ModifyArg{t.Delete()}, nil
-				}))
-			return reaper.Run(gCtx, worker.Watching(pullworker.TombstoneQueue(pushInbox)))
-		})
+		if pushRunGC {
+			// Fallback for a destination without built-in GC (e.g. a direct-to-
+			// PostgreSQL instance): reap this inbox's tombstones on the remote.
+			g.Go(func() error {
+				return gc.RunLoop(gCtx, dst, gc.WithMatch(entroq.MatchExact(pullworker.TombstoneQueue(pushInbox))))
+			})
+		}
 
 		return g.Wait()
 	},
@@ -126,6 +124,7 @@ func init() {
 	flags.DurationVar(&pushTTL, "ttl", pullworker.DefaultTTL, "Tombstone retention window; must exceed worst-case recovery time.")
 	flags.StringVar(&pushSourceName, "source-name", "", "Stable identifier for this source instance, unique across all pushers to the same destination (required).")
 	flags.IntVar(&pushConcurrency, "concurrency", 1, "Number of concurrent push workers.")
+	flags.BoolVar(&pushRunGC, "run-gc", false, "Reap this inbox's dedup tombstones with a local GC loop against the remote destination. Off by default: the destination server collects them. Enable when the remote has no built-in GC (e.g. a direct-to-PostgreSQL instance, or a server run with --no_gc).")
 
 	pushCmd.MarkFlagRequired("dest-entroq")
 	pushCmd.MarkFlagRequired("source-queue")

--- a/cmd/eqlink/cmd/run.go
+++ b/cmd/eqlink/cmd/run.go
@@ -190,7 +190,7 @@ func init() {
 	flags.IntVar(&concurrency, "concurrency", 1, "Number of concurrent receiver goroutines.")
 	flags.DurationVar(&requestTimeout, "request_timeout", 30*time.Second, "Sender request timeout.")
 	flags.DurationVar(&drainTimeout, "drain_timeout", 35*time.Second, "How long to wait for in-flight requests to finish on shutdown.")
-	flags.BoolVar(&runGC, "run-gc", true, "Run a local GC loop scoped to this sidecar's --queue prefix. On by default for now; will default off once the backends run GC server-side.")
+	flags.BoolVar(&runGC, "run-gc", false, "Run a local GC loop scoped to this sidecar's --queue prefix. Off by default; the EntroQ server collects gc= queues itself. Enable only if the server runs with --no_gc.")
 	flags.DurationVar(&gcInterval, "gc_interval", 10*time.Minute, "How often to run the local GC scan (only when --run-gc is set).")
 	flags.DurationVar(&responseGrace, "response_grace", 15*time.Second, "Margin added past --request_timeout when stamping the response queue's collectable-at time, so GC does not delete a response still being awaited. Size to worst-case sender/GC clock skew.")
 	flags.BoolVar(&auditLog, "audit-log", false, "Emit structured JSON audit events to stderr for every request mediated (request_enqueued, request_handled, response_received).")

--- a/cmd/eqlink/cmd/run.go
+++ b/cmd/eqlink/cmd/run.go
@@ -33,6 +33,8 @@ var (
 	namespace           string
 	auditLog            bool
 	tokenReloadInterval time.Duration
+	runGC               bool
+	responseGrace       time.Duration
 )
 
 var runCmd = &cobra.Command{
@@ -90,6 +92,7 @@ Graceful shutdown on SIGINT/SIGTERM:
 		alog := newAuditLogger()
 		sender := async.NewSender(eq, senderAddr,
 			async.WithSenderRequestTimeout(requestTimeout),
+			async.WithSenderResponseGrace(responseGrace),
 			async.WithSenderTLSConfig(tlsCfg),
 			async.WithSenderDomainSuffix(domainSuffix),
 			async.WithSenderNamespace(namespace),
@@ -130,12 +133,14 @@ Graceful shutdown on SIGINT/SIGTERM:
 
 		gcCtx, gcCancel := context.WithCancel(gCtx)
 		defer gcCancel()
-		g.Go(func() error {
-			return async.RunGCLoop(gcCtx, eq, myQueue,
-				async.WithGCInterval(gcInterval),
-				async.WithGCGrace(gcGrace),
-			)
-		})
+		if runGC {
+			g.Go(func() error {
+				return async.RunGCLoop(gcCtx, eq,
+					async.WithGCMatch(entroq.MatchPrefix(myQueue)),
+					async.WithGCInterval(gcInterval),
+				)
+			})
+		}
 
 		// Token reload: reload the bearer token on rotation (SIGHUP or mtime).
 		hupCtx, hupCancel := context.WithCancel(gCtx)
@@ -176,7 +181,7 @@ Graceful shutdown on SIGINT/SIGTERM:
 
 func init() {
 	flags := runCmd.Flags()
-	flags.StringVar(&myQueue, "queue", "", "This sidecar's service queue prefix (required). Receiver watches <prefix>/inbox; GC scans <prefix>/.")
+	flags.StringVar(&myQueue, "queue", "", "This sidecar's service queue prefix (required). Receiver watches <prefix>/inbox.")
 	flags.StringVar(&domainSuffix, "domain-suffix", ".localhost", "Domain suffix stripped from the Host header to derive the target service. E.g. .localhost or .eq.local.")
 	flags.StringVar(&namespace, "namespace", "", "Default namespace prepended to single-label targets. E.g. payments makes bar.localhost route to payments/bar/inbox.")
 	flags.StringVar(&senderAddr, "addr", ":8080", "Address for the sender to listen on.")
@@ -184,8 +189,9 @@ func init() {
 	flags.IntVar(&concurrency, "concurrency", 1, "Number of concurrent receiver goroutines.")
 	flags.DurationVar(&requestTimeout, "request_timeout", 30*time.Second, "Sender request timeout.")
 	flags.DurationVar(&drainTimeout, "drain_timeout", 35*time.Second, "How long to wait for in-flight requests to finish on shutdown.")
-	flags.DurationVar(&gcInterval, "gc_interval", 10*time.Minute, "How often to run the GC scan.")
-	flags.DurationVar(&gcGrace, "gc_grace", 15*time.Second, "Extra time after expiry before GC deletes a response queue.")
+	flags.BoolVar(&runGC, "run-gc", true, "Run a local GC loop scoped to this sidecar's --queue prefix. On by default for now; will default off once the backends run GC server-side.")
+	flags.DurationVar(&gcInterval, "gc_interval", 10*time.Minute, "How often to run the local GC scan (only when --run-gc is set).")
+	flags.DurationVar(&responseGrace, "response_grace", 15*time.Second, "Margin added past --request_timeout when stamping the response queue's collectable-at time, so GC does not delete a response still being awaited. Size to worst-case sender/GC clock skew.")
 	flags.BoolVar(&auditLog, "audit-log", false, "Emit structured JSON audit events to stderr for every request mediated (request_enqueued, request_handled, response_received).")
 	flags.DurationVar(&tokenReloadInterval, "token-reload-interval", 5*time.Minute, "How often to stat the --authz-token-file and reload it if changed. Handles k8s projected token rotation.")
 	runCmd.MarkFlagRequired("queue")

--- a/cmd/eqlink/cmd/run.go
+++ b/cmd/eqlink/cmd/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shiblon/entroq"
 	"github.com/shiblon/entroq/pkg/async"
 	"github.com/shiblon/entroq/pkg/backend/eqgrpc"
+	"github.com/shiblon/entroq/pkg/gc"
 	"github.com/shiblon/entroq/pkg/worker"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -135,9 +136,9 @@ Graceful shutdown on SIGINT/SIGTERM:
 		defer gcCancel()
 		if runGC {
 			g.Go(func() error {
-				return async.RunGCLoop(gcCtx, eq,
-					async.WithGCMatch(entroq.MatchPrefix(myQueue)),
-					async.WithGCInterval(gcInterval),
+				return gc.RunLoop(gcCtx, eq,
+					gc.WithMatch(entroq.MatchPrefix(myQueue)),
+					gc.WithInterval(gcInterval),
 				)
 			})
 		}

--- a/cmd/eqmem/cmd/serve.go
+++ b/cmd/eqmem/cmd/serve.go
@@ -36,7 +36,8 @@ var serve struct {
 	opaURL        string
 	opaPath       string
 
-	noGC bool
+	noGC       bool
+	gcInterval time.Duration
 
 	journal          string
 	createJournalDir bool
@@ -124,7 +125,7 @@ var serveCmd = &cobra.Command{
 
 		svcOpts := []eqsvcgrpc.Option{authzOpt, eqsvcgrpc.WithMeterProvider(mp)}
 		if !serve.noGC {
-			svcOpts = append(svcOpts, eqsvcgrpc.WithGC())
+			svcOpts = append(svcOpts, eqsvcgrpc.WithGC(), eqsvcgrpc.WithGCInterval(serve.gcInterval))
 		}
 
 		svc, err := eqsvcgrpc.New(ctx, eqmem.Opener(
@@ -181,6 +182,7 @@ func init() {
 	f.IntVar(&serve.journalMaxItems, "journal_max_items", 0, "Rotate journal after this many items (0 = default).")
 	f.IntVar(&serve.journalMaxBytes, "journal_max_bytes", 0, "Rotate journal after this many bytes (0 = default).")
 	f.BoolVar(&serve.noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= component).")
+	f.DurationVar(&serve.gcInterval, "gc_interval", time.Minute, "How often the built-in GC scans for collectable queues (when GC is enabled).")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/eqmem/cmd/serve.go
+++ b/cmd/eqmem/cmd/serve.go
@@ -180,7 +180,7 @@ func init() {
 	f.BoolVar(&serve.cleanup, "journal_cleanup", false, "Remove compacted journal files after snapshotting. Requires --journal.")
 	f.IntVar(&serve.journalMaxItems, "journal_max_items", 0, "Rotate journal after this many items (0 = default).")
 	f.IntVar(&serve.journalMaxBytes, "journal_max_bytes", 0, "Rotate journal after this many bytes (0 = default).")
-	f.BoolVar(&serve.noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= or legacy exp= component).")
+	f.BoolVar(&serve.noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= component).")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/eqmem/cmd/serve.go
+++ b/cmd/eqmem/cmd/serve.go
@@ -36,6 +36,8 @@ var serve struct {
 	opaURL        string
 	opaPath       string
 
+	noGC bool
+
 	journal          string
 	createJournalDir bool
 	snapshotAndQuit  bool
@@ -120,12 +122,17 @@ var serveCmd = &cobra.Command{
 		}
 		defer stopMetrics()
 
+		svcOpts := []eqsvcgrpc.Option{authzOpt, eqsvcgrpc.WithMeterProvider(mp)}
+		if !serve.noGC {
+			svcOpts = append(svcOpts, eqsvcgrpc.WithGC())
+		}
+
 		svc, err := eqsvcgrpc.New(ctx, eqmem.Opener(
 			eqmem.WithJournal(serve.journal),
 			eqmem.WithMaxJournalBytes(int64(serve.journalMaxBytes)),
 			eqmem.WithMaxJournalItems(serve.journalMaxItems),
 			eqmem.WithMeterProvider(mp),
-		), authzOpt, eqsvcgrpc.WithMeterProvider(mp))
+		), svcOpts...)
 		if err != nil {
 			return fmt.Errorf("open eqmem backend: %w", err)
 		}
@@ -173,6 +180,7 @@ func init() {
 	f.BoolVar(&serve.cleanup, "journal_cleanup", false, "Remove compacted journal files after snapshotting. Requires --journal.")
 	f.IntVar(&serve.journalMaxItems, "journal_max_items", 0, "Rotate journal after this many items (0 = default).")
 	f.IntVar(&serve.journalMaxBytes, "journal_max_bytes", 0, "Rotate journal after this many bytes (0 = default).")
+	f.BoolVar(&serve.noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= or legacy exp= component).")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/eqpg/cmd/serve.go
+++ b/cmd/eqpg/cmd/serve.go
@@ -38,6 +38,7 @@ var (
 	noListen      bool
 	initSchema    bool
 	noGC          bool
+	gcInterval    time.Duration
 )
 
 var serveCmd = &cobra.Command{
@@ -105,7 +106,7 @@ var serveCmd = &cobra.Command{
 			eqsvcgrpc.WithMeterProvider(mp),
 		}
 		if !noGC {
-			svcOpts = append(svcOpts, eqsvcgrpc.WithGC())
+			svcOpts = append(svcOpts, eqsvcgrpc.WithGC(), eqsvcgrpc.WithGCInterval(gcInterval))
 		}
 
 		svc, err := eqsvcgrpc.New(ctx, opener, svcOpts...)
@@ -156,6 +157,7 @@ func init() {
 	flags.BoolVar(&noListen, "no_listen", true, "Disable the persistent PostgreSQL LISTEN connection. Optimizes singleton deployments.")
 	flags.BoolVar(&initSchema, "init_schema", false, "Initialize the EntroQ schema before serving (idempotent; safe to always set).")
 	flags.BoolVar(&noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= component).")
+	flags.DurationVar(&gcInterval, "gc_interval", time.Minute, "How often the built-in GC scans for collectable queues (when GC is enabled).")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/eqpg/cmd/serve.go
+++ b/cmd/eqpg/cmd/serve.go
@@ -37,6 +37,7 @@ var (
 	heartbeat     time.Duration
 	noListen      bool
 	initSchema    bool
+	noGC          bool
 )
 
 var serveCmd = &cobra.Command{
@@ -98,10 +99,16 @@ var serveCmd = &cobra.Command{
 
 		opener := eqpg.Opener(dbAddr, openerOptions...)
 
-		svc, err := eqsvcgrpc.New(ctx, opener, authzOpt,
-			eqsvcgrpc.WithMetricInterval(5*time.Second),
+		svcOpts := []eqsvcgrpc.Option{
+			authzOpt,
+			eqsvcgrpc.WithMetricInterval(5 * time.Second),
 			eqsvcgrpc.WithMeterProvider(mp),
-		)
+		}
+		if !noGC {
+			svcOpts = append(svcOpts, eqsvcgrpc.WithGC())
+		}
+
+		svc, err := eqsvcgrpc.New(ctx, opener, svcOpts...)
 		if err != nil {
 			return fmt.Errorf("failed to create eqsvcgrpc service: %w", err)
 		}
@@ -148,6 +155,7 @@ func init() {
 	flags.DurationVar(&heartbeat, "heartbeat", 5*time.Second, "Heartbeat interval for this service. Non-zero values designate this node as a cluster Leader.")
 	flags.BoolVar(&noListen, "no_listen", true, "Disable the persistent PostgreSQL LISTEN connection. Optimizes singleton deployments.")
 	flags.BoolVar(&initSchema, "init_schema", false, "Initialize the EntroQ schema before serving (idempotent; safe to always set).")
+	flags.BoolVar(&noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= or legacy exp= component).")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/eqpg/cmd/serve.go
+++ b/cmd/eqpg/cmd/serve.go
@@ -155,7 +155,7 @@ func init() {
 	flags.DurationVar(&heartbeat, "heartbeat", 5*time.Second, "Heartbeat interval for this service. Non-zero values designate this node as a cluster Leader.")
 	flags.BoolVar(&noListen, "no_listen", true, "Disable the persistent PostgreSQL LISTEN connection. Optimizes singleton deployments.")
 	flags.BoolVar(&initSchema, "init_schema", false, "Initialize the EntroQ schema before serving (idempotent; safe to always set).")
-	flags.BoolVar(&noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= or legacy exp= component).")
+	flags.BoolVar(&noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= component).")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/eqredis/cmd/serve.go
+++ b/cmd/eqredis/cmd/serve.go
@@ -32,7 +32,8 @@ var serve struct {
 	opaURL        string
 	opaPath       string
 
-	noGC bool
+	noGC       bool
+	gcInterval time.Duration
 }
 
 var serveCmd = &cobra.Command{
@@ -74,7 +75,7 @@ var serveCmd = &cobra.Command{
 			eqsvcgrpc.WithMeterProvider(mp),
 		}
 		if !serve.noGC {
-			svcOpts = append(svcOpts, eqsvcgrpc.WithGC())
+			svcOpts = append(svcOpts, eqsvcgrpc.WithGC(), eqsvcgrpc.WithGCInterval(serve.gcInterval))
 		}
 
 		svc, err := eqsvcgrpc.New(ctx, opener, svcOpts...)
@@ -119,6 +120,7 @@ func init() {
 	f.StringVar(&serve.opaURL, "opa_url", "", fmt.Sprintf("OPA base URL. Default: %s.", opahttp.DefaultHostURL))
 	f.StringVar(&serve.opaPath, "opa_path", "", fmt.Sprintf("OPA API path. Default: %s.", opahttp.DefaultAPIPath))
 	f.BoolVar(&serve.noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= component).")
+	f.DurationVar(&serve.gcInterval, "gc_interval", time.Minute, "How often the built-in GC scans for collectable queues (when GC is enabled).")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/eqredis/cmd/serve.go
+++ b/cmd/eqredis/cmd/serve.go
@@ -31,6 +31,8 @@ var serve struct {
 	authzStrategy string
 	opaURL        string
 	opaPath       string
+
+	noGC bool
 }
 
 var serveCmd = &cobra.Command{
@@ -66,10 +68,16 @@ var serveCmd = &cobra.Command{
 			eqredis.WithRedisDB(redisDB),
 		)
 
-		svc, err := eqsvcgrpc.New(ctx, opener, authzOpt,
-			eqsvcgrpc.WithMetricInterval(5*time.Second),
+		svcOpts := []eqsvcgrpc.Option{
+			authzOpt,
+			eqsvcgrpc.WithMetricInterval(5 * time.Second),
 			eqsvcgrpc.WithMeterProvider(mp),
-		)
+		}
+		if !serve.noGC {
+			svcOpts = append(svcOpts, eqsvcgrpc.WithGC())
+		}
+
+		svc, err := eqsvcgrpc.New(ctx, opener, svcOpts...)
 		if err != nil {
 			return fmt.Errorf("open eqredis backend: %w", err)
 		}
@@ -110,6 +118,7 @@ func init() {
 	f.StringVar(&serve.authzStrategy, "authz", "none", "Authorization strategy: none, opahttp.")
 	f.StringVar(&serve.opaURL, "opa_url", "", fmt.Sprintf("OPA base URL. Default: %s.", opahttp.DefaultHostURL))
 	f.StringVar(&serve.opaPath, "opa_path", "", fmt.Sprintf("OPA API path. Default: %s.", opahttp.DefaultAPIPath))
+	f.BoolVar(&serve.noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= or legacy exp= component).")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/eqredis/cmd/serve.go
+++ b/cmd/eqredis/cmd/serve.go
@@ -118,7 +118,7 @@ func init() {
 	f.StringVar(&serve.authzStrategy, "authz", "none", "Authorization strategy: none, opahttp.")
 	f.StringVar(&serve.opaURL, "opa_url", "", fmt.Sprintf("OPA base URL. Default: %s.", opahttp.DefaultHostURL))
 	f.StringVar(&serve.opaPath, "opa_path", "", fmt.Sprintf("OPA API path. Default: %s.", opahttp.DefaultAPIPath))
-	f.BoolVar(&serve.noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= or legacy exp= component).")
+	f.BoolVar(&serve.noGC, "no_gc", false, "Disable the built-in GC loop that drains queues opted in by name (a gc= component).")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/deploy/grafana/entroq-dashboard.json
+++ b/deploy/grafana/entroq-dashboard.json
@@ -283,7 +283,6 @@
       "title": "Available Tasks",
       "type": "timeseries"
     },
-
     {
       "datasource": {
         "type": "prometheus",
@@ -437,6 +436,273 @@
       ],
       "title": "Theme Rollup (Total Tasks per L1)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809FD0E3A201658"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809FD0E3A201658"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(entroq_gc_deleted_total{l1=~\"$l1\", l2=~\"$l2\", l3=~\"$l3\"}[5m])) by (l1)",
+          "legendFormat": "{{l1}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GC Deletion Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809FD0E3A201658"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809FD0E3A201658"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(entroq_gc_errors_total{l1=~\"$l1\", l2=~\"$l2\", l3=~\"$l3\"}[5m])) by (kind)",
+          "legendFormat": "{{kind}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GC Error Rate (by kind)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809FD0E3A201658"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809FD0E3A201658"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(entroq_gc_sweep_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GC Sweep Duration (p95)",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",
@@ -524,6 +790,6 @@
   "timezone": "",
   "title": "EntroQ Overview",
   "uid": "entroq_overview",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/pkg/async/bench_test.go
+++ b/pkg/async/bench_test.go
@@ -26,7 +26,7 @@ import (
 // mustStartEntroQ starts a real gRPC server on a loopback TCP port backed by
 // the given opener. Returns a connected EntroQ client and a stop function.
 // Calls t.Fatal on any setup error.
-func mustStartEntroQ(ctx context.Context, t testing.TB, opener entroq.BackendOpener) (*entroq.EntroQ, func()) {
+func mustStartEntroQ(ctx context.Context, t testing.TB, opener entroq.BackendOpener, opts ...eqsvcgrpc.Option) (*entroq.EntroQ, func()) {
 	t.Helper()
 
 	lis, err := net.Listen("tcp", "localhost:0")
@@ -34,7 +34,7 @@ func mustStartEntroQ(ctx context.Context, t testing.TB, opener entroq.BackendOpe
 		t.Fatalf("listen: %v", err)
 	}
 
-	svc, err := eqsvcgrpc.New(ctx, opener)
+	svc, err := eqsvcgrpc.New(ctx, opener, opts...)
 	if err != nil {
 		lis.Close()
 		t.Fatalf("eqsvcgrpc: %v", err)

--- a/pkg/async/gc.go
+++ b/pkg/async/gc.go
@@ -4,32 +4,31 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"path"
-	"strconv"
-	"strings"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/shiblon/entroq"
 	"github.com/shiblon/entroq/pkg/queues"
 )
 
-const (
-	defaultGCInterval = 10 * time.Minute
-	defaultGCGrace    = 15 * time.Second
-)
+const defaultGCInterval = 10 * time.Minute
 
 // GCOption configures RunGCLoop and RunGC.
 type GCOption func(*gcConfig)
 
 type gcConfig struct {
+	match    []entroq.QueuesOpt
 	interval time.Duration
-	grace    time.Duration
+	mp       metric.MeterProvider
 }
 
 func newGCConfig(opts []GCOption) gcConfig {
 	c := gcConfig{
 		interval: defaultGCInterval,
-		grace:    defaultGCGrace,
+		mp:       noop.NewMeterProvider(),
 	}
 	for _, o := range opts {
 		o(&c)
@@ -44,70 +43,148 @@ func WithGCInterval(d time.Duration) GCOption {
 	}
 }
 
-// WithGCGrace sets the extra time after a response queue's expiry timestamp
-// before the GC considers it eligible for deletion. This prevents races at
-// the timeout boundary where a sender may still be reading the response.
-// Defaults to 15 seconds.
-func WithGCGrace(d time.Duration) GCOption {
+// WithGCMatch limits the scan to the queues selected by the standard EntroQ
+// queue matcher (for example entroq.MatchPrefix or entroq.MatchExact). Options
+// accumulate, matching the semantics of eq.Queues. With no match options every
+// queue is scanned.
+func WithGCMatch(opts ...entroq.QueuesOpt) GCOption {
 	return func(c *gcConfig) {
-		c.grace = d
+		c.match = append(c.match, opts...)
 	}
 }
 
-// RunGCLoop runs RunGC periodically until ctx is canceled. Scan errors are
+// WithGCMeterProvider sets the OTel MeterProvider used to emit GC metrics.
+// Defaults to a no-op provider, so metrics are inert unless one is supplied.
+func WithGCMeterProvider(mp metric.MeterProvider) GCOption {
+	return func(c *gcConfig) {
+		if mp != nil {
+			c.mp = mp
+		}
+	}
+}
+
+// gcMetrics holds the OTel instruments emitted by a GC scan.
+type gcMetrics struct {
+	deleted  metric.Int64Counter
+	errors   metric.Int64Counter
+	sweepDur metric.Float64Histogram
+}
+
+func newGCMetrics(mp metric.MeterProvider) (*gcMetrics, error) {
+	m := mp.Meter("entroq.gc")
+	deleted, err := m.Int64Counter("entroq.gc.deleted_total",
+		metric.WithDescription("Total tasks deleted by garbage collection."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gc deleted counter: %w", err)
+	}
+	errors, err := m.Int64Counter("entroq.gc.errors_total",
+		metric.WithDescription("Total errors encountered during garbage collection."),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gc errors counter: %w", err)
+	}
+	sweepDur, err := m.Float64Histogram("entroq.gc.sweep_duration_seconds",
+		metric.WithDescription("Duration of a full GC scan pass in seconds."),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gc sweep duration histogram: %w", err)
+	}
+	return &gcMetrics{deleted: deleted, errors: errors, sweepDur: sweepDur}, nil
+}
+
+// queueAttrs returns a fresh attribute set identifying a queue and its
+// hierarchy, matching the labels used by the queue-size gauge so GC metrics
+// filter under the same dashboard variables.
+func queueAttrs(qname string) []attribute.KeyValue {
+	l1, l2, l3 := queues.PathLabels(qname)
+	return []attribute.KeyValue{
+		attribute.String("queue", qname),
+		attribute.String("l1", l1),
+		attribute.String("l2", l2),
+		attribute.String("l3", l3),
+	}
+}
+
+func (m *gcMetrics) addError(ctx context.Context, qname, kind string) {
+	// queueAttrs allocates a fresh slice, so appending here never aliases.
+	attrs := append(queueAttrs(qname), attribute.String("kind", kind))
+	m.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// RunGCLoop runs a GC scan periodically until ctx is canceled. Scan errors are
 // logged and do not stop the loop.
-func RunGCLoop(ctx context.Context, eq *entroq.EntroQ, root string, opts ...GCOption) error {
+func RunGCLoop(ctx context.Context, eq *entroq.EntroQ, opts ...GCOption) error {
 	c := newGCConfig(opts)
+	m, err := newGCMetrics(c.mp)
+	if err != nil {
+		return fmt.Errorf("gc metrics: %w", err)
+	}
 	t := time.NewTicker(c.interval)
 	defer t.Stop()
-	log.Printf("GC started: root=%q interval=%v grace=%v", root, c.interval, c.grace)
+	log.Printf("GC started: interval=%v", c.interval)
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-t.C:
-			if err := RunGC(ctx, eq, root, opts...); err != nil {
+			if err := scanGC(ctx, eq, c, m); err != nil {
 				log.Printf("gc scan error: %v", err)
 			}
 		}
 	}
 }
 
-// RunGC performs one GC scan pass, deleting tasks from response queues whose
-// expiry timestamp (plus grace) has passed. It uses TryClaim to drain each
-// queue, which provides mutual exclusion between concurrent GC instances.
-func RunGC(ctx context.Context, eq *entroq.EntroQ, root string, opts ...GCOption) error {
+// RunGC performs one GC scan pass, deleting tasks from queues whose gc/exp
+// activation time (plus grace) has passed. It uses TryClaim to drain each
+// queue, which provides mutual exclusion between concurrent GC instances and
+// guarantees it only deletes tasks no worker currently holds. Use WithGCMatch
+// to limit the queues scanned; with none, every queue is scanned.
+func RunGC(ctx context.Context, eq *entroq.EntroQ, opts ...GCOption) error {
 	c := newGCConfig(opts)
+	m, err := newGCMetrics(c.mp)
+	if err != nil {
+		return fmt.Errorf("gc metrics: %w", err)
+	}
+	return scanGC(ctx, eq, c, m)
+}
+
+func scanGC(ctx context.Context, eq *entroq.EntroQ, c gcConfig, m *gcMetrics) error {
+	start := time.Now()
+	defer func() { m.sweepDur.Record(ctx, time.Since(start).Seconds()) }()
+
 	now := time.Now()
 
-	queueMap, err := eq.Queues(ctx, entroq.MatchPrefix(path.Join(root, "/")))
+	queueMap, err := eq.Queues(ctx, c.match...)
 	if err != nil {
 		return fmt.Errorf("list queues: %w", err)
 	}
 
 	var cleaned, skipped int
 	for qname := range queueMap {
-		if !strings.Contains(qname, "/response/") {
+		activateAt, present, err := queues.GCActivation(qname)
+		if !present {
 			continue
 		}
-		params := queues.PathParams(qname)
-		expVals, ok := params["exp"]
-		if !ok {
-			continue
-		}
-		expUnix, err := strconv.ParseInt(expVals[0], 10, 64)
 		if err != nil {
+			// A malformed activation value must never be treated as "collect".
+			log.Printf("gc activation %s: %v", qname, err)
+			m.addError(ctx, qname, "parse")
 			continue
 		}
-		if now.Before(time.Unix(expUnix, 0).Add(c.grace)) {
+		if now.Before(activateAt) {
 			skipped++
 			continue
 		}
+
+		var deleted int64
 		success := true
 		for {
 			task, err := eq.TryClaim(ctx, entroq.From(qname))
 			if err != nil {
 				log.Printf("gc claim %s: %v", qname, err)
+				m.addError(ctx, qname, "claim")
 				success = false
 				break
 			}
@@ -116,8 +193,14 @@ func RunGC(ctx context.Context, eq *entroq.EntroQ, root string, opts ...GCOption
 			}
 			if _, err := eq.Modify(ctx, task.Delete()); err != nil {
 				log.Printf("gc delete task in %s: %v", qname, err)
+				m.addError(ctx, qname, "delete")
 				success = false
+				continue
 			}
+			deleted++
+		}
+		if deleted > 0 {
+			m.deleted.Add(ctx, deleted, metric.WithAttributes(queueAttrs(qname)...))
 		}
 		if success {
 			cleaned++
@@ -125,7 +208,7 @@ func RunGC(ctx context.Context, eq *entroq.EntroQ, root string, opts ...GCOption
 	}
 
 	if cleaned > 0 || skipped > 0 {
-		log.Printf("gc scan: %d response queues cleaned, %d within grace window", cleaned, skipped)
+		log.Printf("gc scan: %d queues cleaned, %d not yet due", cleaned, skipped)
 	}
 
 	return nil

--- a/pkg/async/gc_e2e_test.go
+++ b/pkg/async/gc_e2e_test.go
@@ -1,0 +1,78 @@
+package async_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/shiblon/entroq"
+	"github.com/shiblon/entroq/pkg/async"
+	"github.com/shiblon/entroq/pkg/backend/eqmem"
+	"github.com/shiblon/entroq/pkg/eqsvcgrpc"
+)
+
+// TestServiceGCWithSidecarGCOff validates the target topology once eqlink's
+// local GC is disabled: no async.RunGCLoop runs anywhere (mirroring
+// `eqlink run --run-gc=false`), and the service collects garbage on its own. It
+// confirms both that a live request is unharmed by the service GC scanning
+// underneath it, and that an orphaned response queue is reaped by the service.
+func TestServiceGCWithSidecarGCOff(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	upstream := startEchoUpstream()
+	defer upstream.Close()
+
+	// Service-side GC on, scanning aggressively; deliberately no RunGCLoop.
+	eq, stopEQ := mustStartEntroQ(ctx, t, eqmem.Opener(),
+		eqsvcgrpc.WithGC(), eqsvcgrpc.WithGCInterval(20*time.Millisecond))
+	defer stopEQ()
+
+	const (
+		namespace = "payments"
+		prefix    = "/" + namespace + "/svc"
+	)
+	stopSvc := mustStartReceivers(ctx, t, eq, prefix, upstream.URL, 2)
+	defer stopSvc()
+
+	sender := async.NewSender(eq, "",
+		async.WithSenderDomainSuffix(".test"),
+		async.WithSenderNamespace(namespace),
+	)
+
+	// (a) A live request succeeds even though service GC scans every 20ms: the
+	// sender stamps its response queue collectable far in the future (timeout +
+	// grace), so GC sees it as not-yet-due and leaves it alone.
+	req := httptest.NewRequest(http.MethodGet, "http://svc.test/live", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	sender.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("live request failed with service GC running: status %d: %s", w.Code, w.Body)
+	}
+
+	// (b) An orphaned response queue -- a response the sender abandoned, whose
+	// collect-at time has already passed -- is reaped by the service GC.
+	past := time.Now().Add(-time.Hour).Unix()
+	orphan := fmt.Sprintf("%s/response/gc=%d/deadbeef", prefix, past)
+	if _, err := eq.Modify(ctx, entroq.InsertingInto(orphan, entroq.WithRawValue([]byte("{}")))); err != nil {
+		t.Fatalf("seed orphan response queue: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		sizes, err := eq.Queues(ctx)
+		if err != nil {
+			t.Fatalf("Queues: %v", err)
+		}
+		if sizes[orphan] == 0 {
+			break // collected by the service GC
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("orphan queue %q was not collected by the service GC (size %d)", orphan, sizes[orphan])
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/pkg/async/gc_test.go
+++ b/pkg/async/gc_test.go
@@ -1,0 +1,98 @@
+package async_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/shiblon/entroq"
+	"github.com/shiblon/entroq/pkg/async"
+	"github.com/shiblon/entroq/pkg/backend/eqmem"
+)
+
+// TestRunGC verifies that a single GC pass drains queues whose gc=/exp=
+// activation time has passed while leaving not-yet-due, undirected, and
+// malformed queues untouched.
+func TestRunGC(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	eq, stop := mustStartEntroQ(ctx, t, eqmem.Opener())
+	defer stop()
+
+	past := time.Now().Add(-time.Hour).Unix()
+	future := time.Now().Add(time.Hour).Unix()
+
+	cases := []struct {
+		name      string
+		queue     string
+		wantEmpty bool
+	}{
+		{"legacy exp expired", fmt.Sprintf("/svc/response/exp=%d/aaaa", past), true},
+		{"canonical gc expired", fmt.Sprintf("/svc/gc=%d", past), true},
+		{"gc always on", "/svc/gc=0", true},
+		{"exp not yet due", fmt.Sprintf("/svc/response/exp=%d/bbbb", future), false},
+		{"no gc directive", "/svc/plain", false},
+		{"malformed value is left alone", "/svc/gc=notatime", false},
+	}
+
+	for _, tc := range cases {
+		if _, err := eq.Modify(ctx, entroq.InsertingInto(tc.queue, entroq.WithRawValue([]byte("{}")))); err != nil {
+			t.Fatalf("insert into %q: %v", tc.queue, err)
+		}
+	}
+
+	if err := async.RunGC(ctx, eq); err != nil {
+		t.Fatalf("RunGC: %v", err)
+	}
+
+	sizes, err := eq.Queues(ctx)
+	if err != nil {
+		t.Fatalf("Queues: %v", err)
+	}
+	for _, tc := range cases {
+		got := sizes[tc.queue]
+		switch {
+		case tc.wantEmpty && got != 0:
+			t.Errorf("%s: queue %q should have been collected, still has %d task(s)", tc.name, tc.queue, got)
+		case !tc.wantEmpty && got != 1:
+			t.Errorf("%s: queue %q should have been left alone, has %d task(s) (want 1)", tc.name, tc.queue, got)
+		}
+	}
+}
+
+// TestRunGCRespectsMatch verifies that WithGCMatch scopes the scan: an expired
+// queue outside the match is not collected.
+func TestRunGCRespectsMatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	eq, stop := mustStartEntroQ(ctx, t, eqmem.Opener())
+	defer stop()
+
+	past := time.Now().Add(-time.Hour).Unix()
+	inScope := fmt.Sprintf("/svc/gc=%d", past)
+	outOfScope := fmt.Sprintf("/other/gc=%d", past)
+
+	for _, q := range []string{inScope, outOfScope} {
+		if _, err := eq.Modify(ctx, entroq.InsertingInto(q, entroq.WithRawValue([]byte("{}")))); err != nil {
+			t.Fatalf("insert into %q: %v", q, err)
+		}
+	}
+
+	if err := async.RunGC(ctx, eq, async.WithGCMatch(entroq.MatchPrefix("/svc"))); err != nil {
+		t.Fatalf("RunGC: %v", err)
+	}
+
+	sizes, err := eq.Queues(ctx)
+	if err != nil {
+		t.Fatalf("Queues: %v", err)
+	}
+	if got := sizes[inScope]; got != 0 {
+		t.Errorf("in-scope queue %q should have been collected, still has %d task(s)", inScope, got)
+	}
+	if got := sizes[outOfScope]; got != 1 {
+		t.Errorf("out-of-scope queue %q should have been left alone, has %d task(s) (want 1)", outOfScope, got)
+	}
+}

--- a/pkg/async/sender.go
+++ b/pkg/async/sender.go
@@ -22,7 +22,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-const defaultRequestTimeout = 30 * time.Second
+const (
+	defaultRequestTimeout = 30 * time.Second
+	defaultResponseGrace  = 15 * time.Second
+)
 
 // Sender is an http.Handler that accepts outgoing HTTP calls from a local
 // service and routes them through EntroQ task queues. Each request is
@@ -63,6 +66,7 @@ type Sender struct {
 	name           string
 	auditLog       *slog.Logger
 	requestTimeout time.Duration
+	responseGrace  time.Duration
 	addr           string
 	mp             metric.MeterProvider
 	tlsConfig      *tls.Config
@@ -79,12 +83,24 @@ type Sender struct {
 // SenderOption configures a Sender.
 type SenderOption func(*Sender)
 
-// WithSenderRequestTimeout sets how long ServeHTTP waits for a response task before
-// returning 504. Also used as the exp= value in the response queue name.
-// Defaults to 30 seconds.
+// WithSenderRequestTimeout sets how long ServeHTTP waits for a response task
+// before returning 504. This is the sender's own give-up deadline. Defaults to
+// 30 seconds.
 func WithSenderRequestTimeout(d time.Duration) SenderOption {
 	return func(s *Sender) {
 		s.requestTimeout = d
+	}
+}
+
+// WithSenderResponseGrace sets the margin added past the request timeout when
+// stamping the exp= value in the response queue name. The sender gives up at
+// the request timeout but names the queue collectable only timeout+grace later,
+// so GC never deletes a response this sender might still be awaiting. Size it to
+// the worst-case clock skew between this sender and whatever collects the queue;
+// with well-synchronized clocks it can be small. Defaults to 15 seconds.
+func WithSenderResponseGrace(d time.Duration) SenderOption {
+	return func(s *Sender) {
+		s.responseGrace = d
 	}
 }
 
@@ -150,6 +166,7 @@ func NewSender(eq *entroq.EntroQ, addr string, opts ...SenderOption) *Sender {
 		addr:           addr,
 		domainSuffix:   ".localhost",
 		requestTimeout: defaultRequestTimeout,
+		responseGrace:  defaultResponseGrace,
 		mp:             noop.NewMeterProvider(),
 	}
 	for _, o := range opts {
@@ -306,9 +323,12 @@ func (s *Sender) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	headers := copyHeaders(r.Header)
 
-	expiry := time.Now().Add(s.requestTimeout)
+	// The sender gives up at requestTimeout, but stamps the queue collectable
+	// only requestTimeout+responseGrace later, so GC never deletes a response
+	// this sender might still be awaiting. See WithSenderResponseGrace.
+	collectAt := time.Now().Add(s.requestTimeout + s.responseGrace)
 	responseQueue := path.Join(queuePrefix, "response",
-		fmt.Sprintf("exp=%d", expiry.Unix()),
+		fmt.Sprintf("exp=%d", collectAt.Unix()),
 		entroq.GenHex16())
 
 	env := Envelope{

--- a/pkg/async/sender.go
+++ b/pkg/async/sender.go
@@ -93,7 +93,7 @@ func WithSenderRequestTimeout(d time.Duration) SenderOption {
 }
 
 // WithSenderResponseGrace sets the margin added past the request timeout when
-// stamping the exp= value in the response queue name. The sender gives up at
+// stamping the gc= value in the response queue name. The sender gives up at
 // the request timeout but names the queue collectable only timeout+grace later,
 // so GC never deletes a response this sender might still be awaiting. Size it to
 // the worst-case clock skew between this sender and whatever collects the queue;
@@ -328,7 +328,7 @@ func (s *Sender) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// this sender might still be awaiting. See WithSenderResponseGrace.
 	collectAt := time.Now().Add(s.requestTimeout + s.responseGrace)
 	responseQueue := path.Join(queuePrefix, "response",
-		fmt.Sprintf("exp=%d", collectAt.Unix()),
+		fmt.Sprintf("gc=%d", collectAt.Unix()),
 		entroq.GenHex16())
 
 	env := Envelope{

--- a/pkg/authz/authz.go
+++ b/pkg/authz/authz.go
@@ -82,13 +82,11 @@ type Authorization struct {
 
 // NewHeaderAuthorization creates an authorization structure from a header value.
 func NewHeaderAuthorization(val string) *Authorization {
-	pieces := strings.SplitN(val, " ", 2)
 	az := new(Authorization)
-	switch len(pieces) {
-	case 1:
-		az.Credentials = pieces[0]
-	case 2:
-		az.Type, az.Credentials = pieces[0], pieces[1]
+	if typ, creds, found := strings.Cut(val, " "); found {
+		az.Type, az.Credentials = typ, creds
+	} else {
+		az.Credentials = val
 	}
 	return az
 }

--- a/pkg/backend/eqpg/pg.go
+++ b/pkg/backend/eqpg/pg.go
@@ -1,5 +1,17 @@
 // Package eqpg provides an entroq.Backend using PostgreSQL. Use Opener with
 // entroq.New to create a task client that talks to a PostgreSQL backend.
+//
+// # Garbage collection
+//
+// EntroQ's built-in GC -- which reaps queues that opt in by name with a /gc=
+// component -- runs inside the eqsvcgrpc server, not in this backend. A client
+// that talks directly to PostgreSQL with this package (the many-clients,
+// one-database model, with no "eqpg serve" in front) therefore gets NO built-in
+// GC, and any gc=-marked queues (async response queues, eqlink dedup tombstones,
+// and the like) will accumulate. Such deployments must run a collector
+// themselves: point pkg/gc (gc.RunLoop) at the database, run a dedicated
+// "eqlink gc", or enable the per-command reapers (e.g. "eqlink pull/push
+// --run-gc"). Deployments that go through "eqpg serve" get GC on by default.
 package eqpg
 
 import (

--- a/pkg/eqsvcgrpc/eqsvcgrpc.go
+++ b/pkg/eqsvcgrpc/eqsvcgrpc.go
@@ -38,7 +38,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"sync"
 	"time"
 
@@ -46,6 +45,7 @@ import (
 	"github.com/shiblon/entroq"
 	"github.com/shiblon/entroq/pkg/authz"
 	"github.com/shiblon/entroq/pkg/gc"
+	"github.com/shiblon/entroq/pkg/queues"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -204,17 +204,7 @@ func (s *QSvc) initMetrics() error {
 // with s.mu held.
 func (s *QSvc) observeStats(o metric.Observer, gauge metric.Float64ObservableGauge, stats map[string]*entroq.QueueStat) {
 	for name, stat := range stats {
-		segments := strings.Split(strings.TrimPrefix(name, "/"), "/")
-		l1, l2, l3 := "", "", ""
-		if len(segments) > 0 {
-			l1 = "/" + segments[0]
-		}
-		if len(segments) > 1 {
-			l2 = l1 + "/" + segments[1]
-		}
-		if len(segments) > 2 {
-			l3 = l2 + "/" + segments[2]
-		}
+		l1, l2, l3 := queues.PathLabels(name)
 
 		base := []attribute.KeyValue{
 			attribute.String("queue", name),

--- a/pkg/eqsvcgrpc/eqsvcgrpc.go
+++ b/pkg/eqsvcgrpc/eqsvcgrpc.go
@@ -45,6 +45,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/shiblon/entroq"
 	"github.com/shiblon/entroq/pkg/authz"
+	"github.com/shiblon/entroq/pkg/gc"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -72,6 +73,9 @@ type QSvc struct {
 
 	authzHeader string
 	az          authz.Authorizer
+
+	gcEnabled bool
+	gcCancel  context.CancelFunc
 }
 
 // Option allows QSvc creation options to be defined.
@@ -95,6 +99,16 @@ func WithMetricInterval(d time.Duration) Option {
 			d = 5 * time.Second
 		}
 		s.metricInterval = d
+	}
+}
+
+// WithGC enables a background garbage-collection loop that drains queues opted
+// in by name (a /gc= or legacy /exp= component). It is off by default: the
+// service deletes nothing unless a caller enables it. Server binaries typically
+// enable it and expose their own opt-out flag.
+func WithGC() Option {
+	return func(s *QSvc) {
+		s.gcEnabled = true
 	}
 }
 
@@ -132,6 +146,18 @@ func New(ctx context.Context, opener entroq.BackendOpener, opts ...Option) (*QSv
 
 	if err := svc.initMetrics(); err != nil {
 		return nil, fmt.Errorf("eqsvcgrpc init metrics: %w", err)
+	}
+
+	if svc.gcEnabled {
+		// GC runs against this service's own backend, over every queue, and
+		// stops when Close cancels gcCtx (or the caller cancels ctx).
+		gcCtx, cancel := context.WithCancel(ctx)
+		svc.gcCancel = cancel
+		go func() {
+			if err := gc.RunLoop(gcCtx, impl, gc.WithMeterProvider(svc.mp)); err != nil {
+				log.Printf("eqsvcgrpc: gc loop stopped: %v", err)
+			}
+		}()
 	}
 
 	return svc, nil
@@ -209,8 +235,11 @@ func (s *QSvc) observeStats(o metric.Observer, gauge metric.Float64ObservableGau
 	}
 }
 
-// Close closes the backend connections.
+// Close stops the GC loop, if any, and closes the backend connections.
 func (s *QSvc) Close() error {
+	if s.gcCancel != nil {
+		s.gcCancel()
+	}
 	if err := s.impl.Close(); err != nil {
 		return fmt.Errorf("eqsvcgrpc close: %w", err)
 	}

--- a/pkg/eqsvcgrpc/eqsvcgrpc.go
+++ b/pkg/eqsvcgrpc/eqsvcgrpc.go
@@ -103,7 +103,7 @@ func WithMetricInterval(d time.Duration) Option {
 }
 
 // WithGC enables a background garbage-collection loop that drains queues opted
-// in by name (a /gc= or legacy /exp= component). It is off by default: the
+// in by name (a /gc= component). It is off by default: the
 // service deletes nothing unless a caller enables it. Server binaries typically
 // enable it and expose their own opt-out flag.
 func WithGC() Option {

--- a/pkg/eqsvcgrpc/eqsvcgrpc.go
+++ b/pkg/eqsvcgrpc/eqsvcgrpc.go
@@ -74,8 +74,10 @@ type QSvc struct {
 	authzHeader string
 	az          authz.Authorizer
 
-	gcEnabled bool
-	gcCancel  context.CancelFunc
+	gcEnabled  bool
+	gcInterval time.Duration
+	gcCancel   context.CancelFunc
+	gcDone     chan struct{}
 }
 
 // Option allows QSvc creation options to be defined.
@@ -109,6 +111,14 @@ func WithMetricInterval(d time.Duration) Option {
 func WithGC() Option {
 	return func(s *QSvc) {
 		s.gcEnabled = true
+	}
+}
+
+// WithGCInterval overrides how often the background GC loop scans when GC is
+// enabled via WithGC. Zero (the default) uses the pkg/gc default.
+func WithGCInterval(d time.Duration) Option {
+	return func(s *QSvc) {
+		s.gcInterval = d
 	}
 }
 
@@ -149,12 +159,19 @@ func New(ctx context.Context, opener entroq.BackendOpener, opts ...Option) (*QSv
 	}
 
 	if svc.gcEnabled {
-		// GC runs against this service's own backend, over every queue, and
-		// stops when Close cancels gcCtx (or the caller cancels ctx).
+		// GC runs against this service's own backend, over every queue. Close
+		// cancels gcCtx and waits on gcDone before closing the backend, so the
+		// loop never touches a closed client.
 		gcCtx, cancel := context.WithCancel(ctx)
 		svc.gcCancel = cancel
+		svc.gcDone = make(chan struct{})
+		gcOpts := []gc.Option{gc.WithMeterProvider(svc.mp)}
+		if svc.gcInterval > 0 {
+			gcOpts = append(gcOpts, gc.WithInterval(svc.gcInterval))
+		}
 		go func() {
-			if err := gc.RunLoop(gcCtx, impl, gc.WithMeterProvider(svc.mp)); err != nil {
+			defer close(svc.gcDone)
+			if err := gc.RunLoop(gcCtx, impl, gcOpts...); err != nil {
 				log.Printf("eqsvcgrpc: gc loop stopped: %v", err)
 			}
 		}()
@@ -225,10 +242,12 @@ func (s *QSvc) observeStats(o metric.Observer, gauge metric.Float64ObservableGau
 	}
 }
 
-// Close stops the GC loop, if any, and closes the backend connections.
+// Close stops the GC loop, if any, waits for it to exit, and closes the backend
+// connections.
 func (s *QSvc) Close() error {
 	if s.gcCancel != nil {
 		s.gcCancel()
+		<-s.gcDone
 	}
 	if err := s.impl.Close(); err != nil {
 		return fmt.Errorf("eqsvcgrpc close: %w", err)

--- a/pkg/eqsvcgrpc/eqsvcgrpc_test.go
+++ b/pkg/eqsvcgrpc/eqsvcgrpc_test.go
@@ -1,0 +1,94 @@
+package eqsvcgrpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shiblon/entroq"
+	"github.com/shiblon/entroq/pkg/backend/eqmem"
+)
+
+// waitFor polls cond until it is true or the deadline passes.
+func waitFor(d time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return cond()
+}
+
+func queueSize(ctx context.Context, t *testing.T, eq *entroq.EntroQ, q string) int {
+	t.Helper()
+	sizes, err := eq.Queues(ctx)
+	if err != nil {
+		t.Fatalf("Queues: %v", err)
+	}
+	return sizes[q]
+}
+
+// gc=1 is a Unix timestamp of 1 second past the epoch: always due for GC.
+const dueQueue = "/svc/gc=1"
+
+func insertOne(ctx context.Context, t *testing.T, eq *entroq.EntroQ, q string) {
+	t.Helper()
+	if _, err := eq.Modify(ctx, entroq.InsertingInto(q, entroq.WithRawValue([]byte("{}")))); err != nil {
+		t.Fatalf("insert into %q: %v", q, err)
+	}
+}
+
+// TestQSvcGCEnabledDrains checks that WithGC starts a background loop that
+// drains a due queue against the service's own backend, and that Close cancels
+// and joins that loop (Close returning is proof the goroutine exited).
+func TestQSvcGCEnabledDrains(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	svc, err := New(ctx, eqmem.Opener(), WithGC(), WithGCInterval(10*time.Millisecond))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	insertOne(ctx, t, svc.impl, dueQueue)
+
+	if !waitFor(5*time.Second, func() bool { return queueSize(ctx, t, svc.impl, dueQueue) == 0 }) {
+		t.Fatalf("queue %q was not collected by the background GC loop", dueQueue)
+	}
+
+	// Close cancels and joins the GC goroutine before closing the backend, so
+	// it must return promptly. A hang here means cancellation is broken.
+	done := make(chan error, 1)
+	go func() { done <- svc.Close() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return within 5s: GC goroutine was not canceled")
+	}
+}
+
+// TestQSvcGCDisabledByDefault checks that without WithGC the service starts no
+// GC loop, so a due queue is left untouched.
+func TestQSvcGCDisabledByDefault(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	svc, err := New(ctx, eqmem.Opener(), WithGCInterval(10*time.Millisecond)) // no WithGC
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer svc.Close()
+
+	insertOne(ctx, t, svc.impl, dueQueue)
+
+	// Well beyond several scan intervals, had a loop been running.
+	time.Sleep(200 * time.Millisecond)
+	if got := queueSize(ctx, t, svc.impl, dueQueue); got != 1 {
+		t.Errorf("GC is off by default, but queue %q has %d task(s) (want 1)", dueQueue, got)
+	}
+}

--- a/pkg/gc/gc.go
+++ b/pkg/gc/gc.go
@@ -1,4 +1,15 @@
-package async
+// Package gc periodically collects tasks from queues that opt into garbage
+// collection by naming convention. A queue whose name carries a /gc=<timestamp>
+// (or the legacy /exp=<timestamp>) component becomes eligible once that time
+// passes; gc then drains its claimable tasks with TryClaim, which guarantees it
+// never deletes a task a worker currently holds.
+//
+// Collection is best-effort: it obeys the timestamps it sees and uses only
+// normal claim/modify machinery, so it is safe to run continuously beside live
+// workers. It deliberately does not use the worker.Worker handler loop; it is a
+// standalone periodic scan, optionally scoped by the standard queue matcher, so
+// it works equally well embedded in a server or run on its own.
+package gc
 
 import (
 	"context"
@@ -14,20 +25,20 @@ import (
 	"github.com/shiblon/entroq/pkg/queues"
 )
 
-const defaultGCInterval = 10 * time.Minute
+const defaultInterval = time.Minute
 
-// GCOption configures RunGCLoop and RunGC.
-type GCOption func(*gcConfig)
+// Option configures RunLoop and Run.
+type Option func(*config)
 
-type gcConfig struct {
+type config struct {
 	match    []entroq.QueuesOpt
 	interval time.Duration
 	mp       metric.MeterProvider
 }
 
-func newGCConfig(opts []GCOption) gcConfig {
-	c := gcConfig{
-		interval: defaultGCInterval,
+func newConfig(opts []Option) config {
+	c := config{
+		interval: defaultInterval,
 		mp:       noop.NewMeterProvider(),
 	}
 	for _, o := range opts {
@@ -36,41 +47,41 @@ func newGCConfig(opts []GCOption) gcConfig {
 	return c
 }
 
-// WithGCInterval sets how often the GC scan runs. Defaults to 10 minutes.
-func WithGCInterval(d time.Duration) GCOption {
-	return func(c *gcConfig) {
+// WithInterval sets how often the scan runs. Defaults to one minute.
+func WithInterval(d time.Duration) Option {
+	return func(c *config) {
 		c.interval = d
 	}
 }
 
-// WithGCMatch limits the scan to the queues selected by the standard EntroQ
-// queue matcher (for example entroq.MatchPrefix or entroq.MatchExact). Options
+// WithMatch limits the scan to the queues selected by the standard EntroQ queue
+// matcher (for example entroq.MatchPrefix or entroq.MatchExact). Options
 // accumulate, matching the semantics of eq.Queues. With no match options every
 // queue is scanned.
-func WithGCMatch(opts ...entroq.QueuesOpt) GCOption {
-	return func(c *gcConfig) {
+func WithMatch(opts ...entroq.QueuesOpt) Option {
+	return func(c *config) {
 		c.match = append(c.match, opts...)
 	}
 }
 
-// WithGCMeterProvider sets the OTel MeterProvider used to emit GC metrics.
-// Defaults to a no-op provider, so metrics are inert unless one is supplied.
-func WithGCMeterProvider(mp metric.MeterProvider) GCOption {
-	return func(c *gcConfig) {
+// WithMeterProvider sets the OTel MeterProvider used to emit metrics. Defaults
+// to a no-op provider, so metrics are inert unless one is supplied.
+func WithMeterProvider(mp metric.MeterProvider) Option {
+	return func(c *config) {
 		if mp != nil {
 			c.mp = mp
 		}
 	}
 }
 
-// gcMetrics holds the OTel instruments emitted by a GC scan.
-type gcMetrics struct {
+// metrics holds the OTel instruments emitted by a scan.
+type metrics struct {
 	deleted  metric.Int64Counter
 	errors   metric.Int64Counter
 	sweepDur metric.Float64Histogram
 }
 
-func newGCMetrics(mp metric.MeterProvider) (*gcMetrics, error) {
+func newMetrics(mp metric.MeterProvider) (*metrics, error) {
 	m := mp.Meter("entroq.gc")
 	deleted, err := m.Int64Counter("entroq.gc.deleted_total",
 		metric.WithDescription("Total tasks deleted by garbage collection."),
@@ -91,7 +102,7 @@ func newGCMetrics(mp metric.MeterProvider) (*gcMetrics, error) {
 	if err != nil {
 		return nil, fmt.Errorf("gc sweep duration histogram: %w", err)
 	}
-	return &gcMetrics{deleted: deleted, errors: errors, sweepDur: sweepDur}, nil
+	return &metrics{deleted: deleted, errors: errors, sweepDur: sweepDur}, nil
 }
 
 // queueAttrs returns a fresh attribute set identifying a queue and its
@@ -107,17 +118,17 @@ func queueAttrs(qname string) []attribute.KeyValue {
 	}
 }
 
-func (m *gcMetrics) addError(ctx context.Context, qname, kind string) {
+func (m *metrics) addError(ctx context.Context, qname, kind string) {
 	// queueAttrs allocates a fresh slice, so appending here never aliases.
 	attrs := append(queueAttrs(qname), attribute.String("kind", kind))
 	m.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
-// RunGCLoop runs a GC scan periodically until ctx is canceled. Scan errors are
+// RunLoop runs a scan periodically until ctx is canceled. Scan errors are
 // logged and do not stop the loop.
-func RunGCLoop(ctx context.Context, eq *entroq.EntroQ, opts ...GCOption) error {
-	c := newGCConfig(opts)
-	m, err := newGCMetrics(c.mp)
+func RunLoop(ctx context.Context, eq *entroq.EntroQ, opts ...Option) error {
+	c := newConfig(opts)
+	m, err := newMetrics(c.mp)
 	if err != nil {
 		return fmt.Errorf("gc metrics: %w", err)
 	}
@@ -129,28 +140,28 @@ func RunGCLoop(ctx context.Context, eq *entroq.EntroQ, opts ...GCOption) error {
 		case <-ctx.Done():
 			return nil
 		case <-t.C:
-			if err := scanGC(ctx, eq, c, m); err != nil {
+			if err := scan(ctx, eq, c, m); err != nil {
 				log.Printf("gc scan error: %v", err)
 			}
 		}
 	}
 }
 
-// RunGC performs one GC scan pass, deleting tasks from queues whose gc/exp
-// activation time (plus grace) has passed. It uses TryClaim to drain each
-// queue, which provides mutual exclusion between concurrent GC instances and
-// guarantees it only deletes tasks no worker currently holds. Use WithGCMatch
-// to limit the queues scanned; with none, every queue is scanned.
-func RunGC(ctx context.Context, eq *entroq.EntroQ, opts ...GCOption) error {
-	c := newGCConfig(opts)
-	m, err := newGCMetrics(c.mp)
+// Run performs one scan pass, deleting tasks from queues whose gc/exp
+// activation time has passed. It uses TryClaim to drain each queue, which
+// provides mutual exclusion between concurrent GC instances and guarantees it
+// only deletes tasks no worker currently holds. Use WithMatch to limit the
+// queues scanned; with none, every queue is scanned.
+func Run(ctx context.Context, eq *entroq.EntroQ, opts ...Option) error {
+	c := newConfig(opts)
+	m, err := newMetrics(c.mp)
 	if err != nil {
 		return fmt.Errorf("gc metrics: %w", err)
 	}
-	return scanGC(ctx, eq, c, m)
+	return scan(ctx, eq, c, m)
 }
 
-func scanGC(ctx context.Context, eq *entroq.EntroQ, c gcConfig, m *gcMetrics) error {
+func scan(ctx context.Context, eq *entroq.EntroQ, c config, m *metrics) error {
 	start := time.Now()
 	defer func() { m.sweepDur.Record(ctx, time.Since(start).Seconds()) }()
 

--- a/pkg/gc/gc.go
+++ b/pkg/gc/gc.go
@@ -1,7 +1,7 @@
 // Package gc periodically collects tasks from queues that opt into garbage
 // collection by naming convention. A queue whose name carries a /gc=<timestamp>
-// (or the legacy /exp=<timestamp>) component becomes eligible once that time
-// passes; gc then drains its claimable tasks with TryClaim, which guarantees it
+// component becomes eligible once that time passes; gc then drains its
+// claimable tasks with TryClaim, which guarantees it
 // never deletes a task a worker currently holds.
 //
 // Collection is best-effort: it obeys the timestamps it sees and uses only
@@ -183,8 +183,8 @@ func RunLoop(ctx context.Context, eq *entroq.EntroQ, opts ...Option) error {
 	}
 }
 
-// Run performs one scan pass, deleting tasks from queues whose gc/exp
-// activation time has passed. It uses TryClaim to drain each queue, which
+// Run performs one scan pass, deleting tasks from queues whose gc activation
+// time has passed. It uses TryClaim to drain each queue, which
 // provides mutual exclusion between concurrent GC instances and guarantees it
 // only deletes tasks no worker currently holds. Use WithMatch to limit the
 // queues scanned; with none, every queue is scanned.

--- a/pkg/gc/gc.go
+++ b/pkg/gc/gc.go
@@ -25,24 +25,42 @@ import (
 	"github.com/shiblon/entroq/pkg/queues"
 )
 
-const defaultInterval = time.Minute
+const (
+	defaultInterval   = time.Minute
+	defaultMaxSize    = 100
+	maxBatchSize      = 1000
+	defaultBatchPause = 100 * time.Millisecond
+)
 
 // Option configures RunLoop and Run.
 type Option func(*config)
 
 type config struct {
-	match    []entroq.QueuesOpt
-	interval time.Duration
-	mp       metric.MeterProvider
+	match      []entroq.QueuesOpt
+	interval   time.Duration
+	maxSize    int
+	batchPause time.Duration
+	mp         metric.MeterProvider
 }
 
 func newConfig(opts []Option) config {
 	c := config{
-		interval: defaultInterval,
-		mp:       noop.NewMeterProvider(),
+		interval:   defaultInterval,
+		maxSize:    defaultMaxSize,
+		batchPause: defaultBatchPause,
+		mp:         noop.NewMeterProvider(),
 	}
 	for _, o := range opts {
 		o(&c)
+	}
+	if c.maxSize <= 0 {
+		c.maxSize = defaultMaxSize
+	}
+	if c.maxSize > maxBatchSize {
+		c.maxSize = maxBatchSize
+	}
+	if c.batchPause < 0 {
+		c.batchPause = 0
 	}
 	return c
 }
@@ -51,6 +69,24 @@ func newConfig(opts []Option) config {
 func WithInterval(d time.Duration) Option {
 	return func(c *config) {
 		c.interval = d
+	}
+}
+
+// WithMaxSize sets the maximum number of tasks GC claims and deletes per batch
+// within a single queue before it pauses. Values above 1000 are capped;
+// non-positive values fall back to the default of 100.
+func WithMaxSize(n int) Option {
+	return func(c *config) {
+		c.maxSize = n
+	}
+}
+
+// WithBatchPause sets how long GC rests between full batches while draining a
+// single queue, so a large backlog does not monopolize the backend. The pause
+// honors context cancellation. Defaults to 100ms; zero disables it.
+func WithBatchPause(d time.Duration) Option {
+	return func(c *config) {
+		c.batchPause = d
 	}
 }
 
@@ -189,31 +225,7 @@ func scan(ctx context.Context, eq *entroq.EntroQ, c config, m *metrics) error {
 			continue
 		}
 
-		var deleted int64
-		success := true
-		for {
-			task, err := eq.TryClaim(ctx, entroq.From(qname))
-			if err != nil {
-				log.Printf("gc claim %s: %v", qname, err)
-				m.addError(ctx, qname, "claim")
-				success = false
-				break
-			}
-			if task == nil {
-				break
-			}
-			if _, err := eq.Modify(ctx, task.Delete()); err != nil {
-				log.Printf("gc delete task in %s: %v", qname, err)
-				m.addError(ctx, qname, "delete")
-				success = false
-				continue
-			}
-			deleted++
-		}
-		if deleted > 0 {
-			m.deleted.Add(ctx, deleted, metric.WithAttributes(queueAttrs(qname)...))
-		}
-		if success {
+		if drainQueue(ctx, eq, c, m, qname) {
 			cleaned++
 		}
 	}
@@ -223,4 +235,55 @@ func scan(ctx context.Context, eq *entroq.EntroQ, c config, m *metrics) error {
 	}
 
 	return nil
+}
+
+// drainQueue claims and deletes the claimable tasks in qname in batches of at
+// most c.maxSize, committing each batch in a single Modify. Every task in a
+// batch is held by this claimant, so the atomic delete cannot be tripped by a
+// stale version. Between full batches it rests for c.batchPause so a large
+// backlog does not monopolize the backend. It returns true if it finished
+// without a claim or delete error.
+func drainQueue(ctx context.Context, eq *entroq.EntroQ, c config, m *metrics, qname string) bool {
+	for {
+		var batch []entroq.ModifyArg
+		claimErr := false
+		for len(batch) < c.maxSize {
+			task, err := eq.TryClaim(ctx, entroq.From(qname))
+			if err != nil {
+				log.Printf("gc claim %s: %v", qname, err)
+				m.addError(ctx, qname, "claim")
+				claimErr = true
+				break
+			}
+			if task == nil {
+				break
+			}
+			batch = append(batch, task.Delete())
+		}
+
+		// Delete whatever we managed to claim, even if claiming then errored;
+		// we hold those leases and abandoning them just delays their cleanup.
+		if len(batch) > 0 {
+			if _, err := eq.Modify(ctx, batch...); err != nil {
+				log.Printf("gc delete batch in %s: %v", qname, err)
+				m.addError(ctx, qname, "delete")
+				return false
+			}
+			m.deleted.Add(ctx, int64(len(batch)), metric.WithAttributes(queueAttrs(qname)...))
+		}
+
+		if claimErr {
+			return false
+		}
+		// A partial batch means the queue is drained; a full one may have left
+		// more behind, so rest and continue.
+		if len(batch) < c.maxSize {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return true
+		case <-time.After(c.batchPause):
+		}
+	}
 }

--- a/pkg/gc/gc_test.go
+++ b/pkg/gc/gc_test.go
@@ -21,9 +21,9 @@ func newTestEQ(ctx context.Context, t *testing.T) *entroq.EntroQ {
 	return eq
 }
 
-// TestRun verifies that a single scan drains queues whose gc=/exp= activation
-// time has passed while leaving not-yet-due, undirected, and malformed queues
-// untouched.
+// TestRun verifies that a single scan drains queues whose gc= activation time
+// has passed while leaving not-yet-due, undirected, malformed, and legacy exp=
+// queues untouched.
 func TestRun(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -38,10 +38,10 @@ func TestRun(t *testing.T) {
 		queue     string
 		wantEmpty bool
 	}{
-		{"legacy exp expired", fmt.Sprintf("/svc/response/exp=%d/aaaa", past), true},
 		{"canonical gc expired", fmt.Sprintf("/svc/gc=%d", past), true},
 		{"gc always on", "/svc/gc=0", true},
-		{"exp not yet due", fmt.Sprintf("/svc/response/exp=%d/bbbb", future), false},
+		{"gc not yet due", fmt.Sprintf("/svc/gc=%d/leaf", future), false},
+		{"exp is ignored", fmt.Sprintf("/svc/response/exp=%d/aaaa", past), false},
 		{"no gc directive", "/svc/plain", false},
 		{"malformed value is left alone", "/svc/gc=notatime", false},
 	}

--- a/pkg/gc/gc_test.go
+++ b/pkg/gc/gc_test.go
@@ -71,6 +71,39 @@ func TestRun(t *testing.T) {
 	}
 }
 
+// TestRunBatches verifies that a queue holding more tasks than one batch is
+// fully drained across multiple batches (with a pause between them).
+func TestRunBatches(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	eq := newTestEQ(ctx, t)
+
+	past := time.Now().Add(-time.Hour).Unix()
+	q := fmt.Sprintf("/svc/gc=%d", past)
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		if _, err := eq.Modify(ctx, entroq.InsertingInto(q, entroq.WithRawValue([]byte("{}")))); err != nil {
+			t.Fatalf("insert %d into %q: %v", i, q, err)
+		}
+	}
+
+	// MaxSize below the task count forces multiple batches; a tiny pause keeps
+	// the test fast while still exercising the between-batch rest path.
+	if err := gc.Run(ctx, eq, gc.WithMaxSize(2), gc.WithBatchPause(time.Millisecond)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	sizes, err := eq.Queues(ctx)
+	if err != nil {
+		t.Fatalf("Queues: %v", err)
+	}
+	if got := sizes[q]; got != 0 {
+		t.Errorf("queue %q should be fully drained across batches, has %d task(s)", q, got)
+	}
+}
+
 // TestRunRespectsMatch verifies that WithMatch scopes the scan: an expired
 // queue outside the match is not collected.
 func TestRunRespectsMatch(t *testing.T) {

--- a/pkg/gc/gc_test.go
+++ b/pkg/gc/gc_test.go
@@ -1,4 +1,4 @@
-package async_test
+package gc_test
 
 import (
 	"context"
@@ -7,19 +7,28 @@ import (
 	"time"
 
 	"github.com/shiblon/entroq"
-	"github.com/shiblon/entroq/pkg/async"
 	"github.com/shiblon/entroq/pkg/backend/eqmem"
+	"github.com/shiblon/entroq/pkg/gc"
 )
 
-// TestRunGC verifies that a single GC pass drains queues whose gc=/exp=
-// activation time has passed while leaving not-yet-due, undirected, and
-// malformed queues untouched.
-func TestRunGC(t *testing.T) {
+func newTestEQ(ctx context.Context, t *testing.T) *entroq.EntroQ {
+	t.Helper()
+	eq, err := entroq.New(ctx, eqmem.Opener())
+	if err != nil {
+		t.Fatalf("open eqmem: %v", err)
+	}
+	t.Cleanup(func() { eq.Close() })
+	return eq
+}
+
+// TestRun verifies that a single scan drains queues whose gc=/exp= activation
+// time has passed while leaving not-yet-due, undirected, and malformed queues
+// untouched.
+func TestRun(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	eq, stop := mustStartEntroQ(ctx, t, eqmem.Opener())
-	defer stop()
+	eq := newTestEQ(ctx, t)
 
 	past := time.Now().Add(-time.Hour).Unix()
 	future := time.Now().Add(time.Hour).Unix()
@@ -43,8 +52,8 @@ func TestRunGC(t *testing.T) {
 		}
 	}
 
-	if err := async.RunGC(ctx, eq); err != nil {
-		t.Fatalf("RunGC: %v", err)
+	if err := gc.Run(ctx, eq); err != nil {
+		t.Fatalf("Run: %v", err)
 	}
 
 	sizes, err := eq.Queues(ctx)
@@ -62,14 +71,13 @@ func TestRunGC(t *testing.T) {
 	}
 }
 
-// TestRunGCRespectsMatch verifies that WithGCMatch scopes the scan: an expired
+// TestRunRespectsMatch verifies that WithMatch scopes the scan: an expired
 // queue outside the match is not collected.
-func TestRunGCRespectsMatch(t *testing.T) {
+func TestRunRespectsMatch(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	eq, stop := mustStartEntroQ(ctx, t, eqmem.Opener())
-	defer stop()
+	eq := newTestEQ(ctx, t)
 
 	past := time.Now().Add(-time.Hour).Unix()
 	inScope := fmt.Sprintf("/svc/gc=%d", past)
@@ -81,8 +89,8 @@ func TestRunGCRespectsMatch(t *testing.T) {
 		}
 	}
 
-	if err := async.RunGC(ctx, eq, async.WithGCMatch(entroq.MatchPrefix("/svc"))); err != nil {
-		t.Fatalf("RunGC: %v", err)
+	if err := gc.Run(ctx, eq, gc.WithMatch(entroq.MatchPrefix("/svc"))); err != nil {
+		t.Fatalf("Run: %v", err)
 	}
 
 	sizes, err := eq.Queues(ctx)

--- a/pkg/queues/gc.go
+++ b/pkg/queues/gc.go
@@ -1,0 +1,81 @@
+package queues
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// gcKeys are the queue-name path keys that declare a garbage-collection
+// activation time. "gc" is canonical; "exp" is a grandfathered alias emitted by
+// older async response queues, kept so that upgrading a server does not strand
+// queues already named with it.
+var gcKeys = map[string]bool{"gc": true, "exp": true}
+
+// ParseGCActivation interprets a garbage-collection activation value: the time
+// after which a queue's claimable tasks may be collected.
+//
+// The empty string means "always active" and yields the zero Time. A value
+// consisting only of decimal digits is a Unix timestamp in SECONDS, so "0" is
+// the epoch (also effectively always active). Millisecond timestamps are not
+// detected, so millisecond-based clients such as JavaScript must divide by
+// 1000. Any other value is parsed as RFC3339Nano, which accepts both plain and
+// fractional-second forms (including the output of JavaScript's
+// Date.toISOString).
+//
+// Per-task arrival time still governs when an individual task is collected;
+// this value is only the whole-queue on-switch.
+func ParseGCActivation(value string) (time.Time, error) {
+	if value == "" {
+		return time.Time{}, nil
+	}
+	if isAllDigits(value) {
+		secs, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("gc activation unix seconds %q: %w", value, err)
+		}
+		return time.Unix(secs, 0).UTC(), nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("gc activation timestamp %q: %w", value, err)
+	}
+	return t, nil
+}
+
+// GCActivation resolves a queue's garbage-collection policy from its /gc=
+// (canonical) and /exp= (legacy async alias) path components. present is false
+// when neither key appears. When several are present the most specific one
+// wins: the last such component in path order, regardless of which key spells
+// it. A malformed value yields an error, and the caller must not collect the
+// queue on error.
+func GCActivation(qname string) (activateAt time.Time, present bool, err error) {
+	last := ""
+	for _, component := range PathComponents(qname) {
+		if !strings.HasPrefix(component, "/") {
+			continue
+		}
+		key, val, found := strings.Cut(component[1:], "=")
+		if !found || !gcKeys[key] {
+			continue
+		}
+		last, present = val, true
+	}
+	if !present {
+		return time.Time{}, false, nil
+	}
+	at, err := ParseGCActivation(last)
+	return at, true, err
+}
+
+// isAllDigits reports whether s is non-empty and composed solely of the ASCII
+// digits 0-9 (no sign, decimal point, or whitespace).
+func isAllDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return s != ""
+}

--- a/pkg/queues/gc.go
+++ b/pkg/queues/gc.go
@@ -7,12 +7,6 @@ import (
 	"time"
 )
 
-// gcKeys are the queue-name path keys that declare a garbage-collection
-// activation time. "gc" is canonical; "exp" is a grandfathered alias emitted by
-// older async response queues, kept so that upgrading a server does not strand
-// queues already named with it.
-var gcKeys = map[string]bool{"gc": true, "exp": true}
-
 // ParseGCActivation interprets a garbage-collection activation value: the time
 // after which a queue's claimable tasks may be collected.
 //
@@ -44,12 +38,10 @@ func ParseGCActivation(value string) (time.Time, error) {
 	return t, nil
 }
 
-// GCActivation resolves a queue's garbage-collection policy from its /gc=
-// (canonical) and /exp= (legacy async alias) path components. present is false
-// when neither key appears. When several are present the most specific one
-// wins: the last such component in path order, regardless of which key spells
-// it. A malformed value yields an error, and the caller must not collect the
-// queue on error.
+// GCActivation resolves a queue's garbage-collection policy from its /gc= path
+// components. present is false when no /gc= component appears. When several are
+// present the most specific one wins: the last in path order. A malformed value
+// yields an error, and the caller must not collect the queue on error.
 func GCActivation(qname string) (activateAt time.Time, present bool, err error) {
 	last := ""
 	for _, component := range PathComponents(qname) {
@@ -57,7 +49,7 @@ func GCActivation(qname string) (activateAt time.Time, present bool, err error) 
 			continue
 		}
 		key, val, found := strings.Cut(component[1:], "=")
-		if !found || !gcKeys[key] {
+		if !found || key != "gc" {
 			continue
 		}
 		last, present = val, true

--- a/pkg/queues/gc_test.go
+++ b/pkg/queues/gc_test.go
@@ -1,0 +1,218 @@
+package queues
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestParseGCActivation(t *testing.T) {
+	rfc := time.Date(2026, 7, 2, 15, 4, 5, 0, time.UTC)
+
+	cases := []struct {
+		name    string
+		value   string
+		want    time.Time // ignored when wantErr is true
+		wantErr bool
+	}{
+		{
+			name:  "empty is always active",
+			value: "",
+			want:  time.Time{},
+		},
+		{
+			name:  "zero is epoch",
+			value: "0",
+			want:  time.Unix(0, 0).UTC(),
+		},
+		{
+			name:  "unix seconds",
+			value: "1719000000",
+			want:  time.Unix(1719000000, 0).UTC(),
+		},
+		{
+			name:  "rfc3339",
+			value: "2026-07-02T15:04:05Z",
+			want:  rfc,
+		},
+		{
+			name:  "rfc3339 fractional seconds (JS toISOString)",
+			value: "2026-07-02T15:04:05.000Z",
+			want:  rfc,
+		},
+		{
+			name:    "not a timestamp",
+			value:   "someday",
+			wantErr: true,
+		},
+		{
+			name:    "malformed rfc3339",
+			value:   "2026-13-40T99:99:99Z",
+			wantErr: true,
+		},
+		{
+			name:    "decimal is not unix and not rfc3339",
+			value:   "12.5",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range cases {
+		got, err := ParseGCActivation(test.value)
+		if test.wantErr {
+			if err == nil {
+				t.Errorf("TestParseGCActivation %q: wanted error, got %v", test.name, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("TestParseGCActivation %q: unexpected error: %v", test.name, err)
+			continue
+		}
+		if !got.Equal(test.want) {
+			t.Errorf("TestParseGCActivation %q: wanted %v, got %v", test.name, test.want, got)
+		}
+	}
+}
+
+func TestGCActivation(t *testing.T) {
+	cases := []struct {
+		name    string
+		queue   string
+		present bool
+		want    time.Time // ignored unless present && !wantErr
+		wantErr bool
+	}{
+		{
+			name:  "no gc key",
+			queue: "/some/path/somewhere",
+		},
+		{
+			name:    "canonical gc always on",
+			queue:   "/tasks/gc=0",
+			present: true,
+			want:    time.Unix(0, 0).UTC(),
+		},
+		{
+			name:    "empty value is always on",
+			queue:   "/tasks/gc=/leaf",
+			present: true,
+			want:    time.Time{},
+		},
+		{
+			name:    "legacy exp alias",
+			queue:   "/tasks/response/exp=1719000000",
+			present: true,
+			want:    time.Unix(1719000000, 0).UTC(),
+		},
+		{
+			name:    "last of same key wins",
+			queue:   "/gc=100/sub/gc=200",
+			present: true,
+			want:    time.Unix(200, 0).UTC(),
+		},
+		{
+			name:    "last across keys wins (exp after gc)",
+			queue:   "/gc=200/sub/exp=100",
+			present: true,
+			want:    time.Unix(100, 0).UTC(),
+		},
+		{
+			name:    "last across keys wins (gc after exp)",
+			queue:   "/exp=100/sub/gc=200",
+			present: true,
+			want:    time.Unix(200, 0).UTC(),
+		},
+		{
+			name:    "rfc3339 value",
+			queue:   "/tasks/gc=2026-07-02T15:04:05Z",
+			present: true,
+			want:    time.Date(2026, 7, 2, 15, 4, 5, 0, time.UTC),
+		},
+		{
+			name:    "malformed value present but errors",
+			queue:   "/tasks/gc=whenever",
+			present: true,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range cases {
+		got, present, err := GCActivation(test.queue)
+		if present != test.present {
+			t.Errorf("TestGCActivation %q: wanted present=%v, got %v", test.name, test.present, present)
+		}
+		if test.wantErr {
+			if err == nil {
+				t.Errorf("TestGCActivation %q: wanted error, got %v", test.name, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("TestGCActivation %q: unexpected error: %v", test.name, err)
+			continue
+		}
+		if test.present && !got.Equal(test.want) {
+			t.Errorf("TestGCActivation %q: wanted %v, got %v", test.name, test.want, got)
+		}
+	}
+}
+
+func TestPathLabels(t *testing.T) {
+	cases := []struct {
+		name       string
+		queue      string
+		l1, l2, l3 string
+	}{
+		{
+			name:  "empty",
+			queue: "",
+		},
+		{
+			name:  "one level",
+			queue: "/a",
+			l1:    "/a",
+		},
+		{
+			name:  "two levels",
+			queue: "/a/b",
+			l1:    "/a",
+			l2:    "/a/b",
+		},
+		{
+			name:  "three levels",
+			queue: "/a/b/c",
+			l1:    "/a",
+			l2:    "/a/b",
+			l3:    "/a/b/c",
+		},
+		{
+			name:  "fourth level ignored",
+			queue: "/a/b/c/d",
+			l1:    "/a",
+			l2:    "/a/b",
+			l3:    "/a/b/c",
+		},
+		{
+			name:  "escaped slash stays within a level",
+			queue: "/a\\/x/b",
+			l1:    "/a/x",
+			l2:    "/a/x/b",
+		},
+	}
+
+	for _, test := range cases {
+		l1, l2, l3 := PathLabels(test.queue)
+		if l1 != test.l1 || l2 != test.l2 || l3 != test.l3 {
+			t.Errorf("TestPathLabels %q: wanted (%q, %q, %q), got (%q, %q, %q)",
+				test.name, test.l1, test.l2, test.l3, l1, l2, l3)
+		}
+	}
+}
+
+func ExampleGCActivation() {
+	// The most specific (last) gc/exp component wins, across either key.
+	at, present, _ := GCActivation("/tasks/exp=100/response/gc=200")
+	fmt.Printf("present=%v activateAt=%d\n", present, at.Unix())
+	// Output: present=true activateAt=200
+}

--- a/pkg/queues/gc_test.go
+++ b/pkg/queues/gc_test.go
@@ -100,26 +100,12 @@ func TestGCActivation(t *testing.T) {
 			want:    time.Time{},
 		},
 		{
-			name:    "legacy exp alias",
-			queue:   "/tasks/response/exp=1719000000",
-			present: true,
-			want:    time.Unix(1719000000, 0).UTC(),
+			name:  "exp is ignored",
+			queue: "/tasks/response/exp=1719000000",
 		},
 		{
-			name:    "last of same key wins",
+			name:    "last gc wins",
 			queue:   "/gc=100/sub/gc=200",
-			present: true,
-			want:    time.Unix(200, 0).UTC(),
-		},
-		{
-			name:    "last across keys wins (exp after gc)",
-			queue:   "/gc=200/sub/exp=100",
-			present: true,
-			want:    time.Unix(100, 0).UTC(),
-		},
-		{
-			name:    "last across keys wins (gc after exp)",
-			queue:   "/exp=100/sub/gc=200",
 			present: true,
 			want:    time.Unix(200, 0).UTC(),
 		},
@@ -211,8 +197,8 @@ func TestPathLabels(t *testing.T) {
 }
 
 func ExampleGCActivation() {
-	// The most specific (last) gc/exp component wins, across either key.
-	at, present, _ := GCActivation("/tasks/exp=100/response/gc=200")
+	// The most specific (last) gc component wins.
+	at, present, _ := GCActivation("/tasks/gc=100/response/gc=200")
 	fmt.Printf("present=%v activateAt=%d\n", present, at.Unix())
 	// Output: present=true activateAt=200
 }

--- a/pkg/queues/queues.go
+++ b/pkg/queues/queues.go
@@ -38,6 +38,25 @@ func PathComponents(qname string) []string {
 	return components
 }
 
+// PathLabels returns up to three cumulative path labels for a queue name,
+// suitable for grouping metrics by hierarchy: for "/a/b/c/d" it returns "/a",
+// "/a/b", and "/a/b/c". Components beyond the third are ignored, and unused
+// levels are empty. It uses the same escape-aware splitting as PathComponents,
+// so an escaped slash within a component does not begin a new level.
+func PathLabels(qname string) (l1, l2, l3 string) {
+	c := PathComponents(qname)
+	if len(c) > 0 {
+		l1 = c[0]
+	}
+	if len(c) > 1 {
+		l2 = l1 + c[1]
+	}
+	if len(c) > 2 {
+		l3 = l2 + c[2]
+	}
+	return l1, l2, l3
+}
+
 // PathParams returns a map from strings to slices of values. It looks
 // through the queue name, assuing that it is basically structured like a path,
 // with some `/key=value/` components, and extracts those key/value pairs into

--- a/pkg/queues/queues.go
+++ b/pkg/queues/queues.go
@@ -74,11 +74,10 @@ func PathParams(qname string) map[string][]string {
 		// Remove the prefix, which we know uses 1 byte, now:
 		keyVal := component[1:]
 
-		pieces := strings.SplitN(keyVal, "=", 2)
-		if len(pieces) != 2 {
+		key, val, found := strings.Cut(keyVal, "=")
+		if !found {
 			continue
 		}
-		key, val := pieces[0], pieces[1]
 		params[key] = append(params[key], val)
 	}
 	if len(params) == 0 {

--- a/pkg/workers/pullworker/gc_reap_test.go
+++ b/pkg/workers/pullworker/gc_reap_test.go
@@ -1,0 +1,65 @@
+package pullworker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shiblon/entroq"
+	"github.com/shiblon/entroq/pkg/gc"
+	"github.com/shiblon/entroq/pkg/queues"
+)
+
+// TestTombstoneQueueGCEligible confirms the default tombstone queue opts into
+// server-side GC via its name, so a running server reaps its orphans without a
+// separate reaper.
+func TestTombstoneQueueGCEligible(t *testing.T) {
+	q := TombstoneQueue("/svc/inbox")
+	at, present, err := queues.GCActivation(q)
+	if err != nil {
+		t.Fatalf("GCActivation(%q): %v", q, err)
+	}
+	if !present {
+		t.Fatalf("tombstone queue %q is not GC-eligible; the server would never reap it", q)
+	}
+	if at.After(time.Now()) {
+		t.Errorf("tombstone queue %q should be collectable now (gc=0), got activate-at %v", q, at)
+	}
+}
+
+// TestTombstonesReapedByGC confirms that an orphaned tombstone -- one whose TTL
+// (arrival time) has elapsed -- is deleted by the GC pass the destination server
+// runs, so no separate reaper is needed. It also implicitly checks that the
+// tombstone is left alone until its TTL, since GC only claims arrived tasks.
+func TestTombstonesReapedByGC(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dst := memClient(ctx, t)
+
+	tq := TombstoneQueue("/svc/inbox")
+	if _, err := dst.Modify(ctx, entroq.InsertingInto(tq,
+		entroq.WithID("xfer-orphan"),
+		entroq.WithArrivalTimeIn(20*time.Millisecond),
+	)); err != nil {
+		t.Fatalf("seed orphan tombstone: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if err := gc.Run(ctx, dst); err != nil {
+			t.Fatalf("gc run: %v", err)
+		}
+		sizes, err := dst.Queues(ctx)
+		if err != nil {
+			t.Fatalf("Queues: %v", err)
+		}
+		if sizes[tq] == 0 {
+			return // reaped once its arrival time passed
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("orphan tombstone in %q not reaped by GC (size %d)", tq, sizes[tq])
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/pkg/workers/pullworker/pullworker.go
+++ b/pkg/workers/pullworker/pullworker.go
@@ -49,12 +49,14 @@
 // interrupts the worker between delivery and that cleanup.
 //
 // Those orphans are reaped by arrival time: each tombstone is inserted At = now
-// + TTL, and a plain delete-reaper claims and removes any whose time has come
-// (point one at the tombstone queue). The TTL is the dedup-retention window and
-// the single safety knob: a duplicate is only possible if a tombstone is reaped
-// while a crashed pull can still re-attempt -- i.e. only if recovery takes longer
-// than the TTL. Size it well above worst-case recovery. The reaper is the safety
-// net for crash orphans, not the primary cleanup path.
+// + TTL, and the destination server's built-in garbage collector removes any
+// whose time has come -- the tombstone queue carries a gc= marker (see
+// TombstoneQueue), so no separate reaper is needed as long as that server runs
+// GC, which is the default. The TTL is the dedup-retention window and the single
+// safety knob: a duplicate is only possible if a tombstone is reaped while a
+// crashed pull can still re-attempt -- i.e. only if recovery takes longer than
+// the TTL. Size it well above worst-case recovery. GC is the safety net for
+// crash orphans, not the primary cleanup path.
 package pullworker
 
 import (
@@ -109,8 +111,9 @@ func WithInbox(q string) Option {
 	}
 }
 
-// WithTombstoneQueue overrides the tombstone queue (default <inbox>/_tombstone).
-// This is the queue a delete-reaper should be pointed at.
+// WithTombstoneQueue overrides the tombstone queue (default from TombstoneQueue).
+// An override should include a gc= component (see TombstoneQueue) so the
+// destination server's GC reaps its orphans; otherwise point your own reaper at it.
 func WithTombstoneQueue(q string) Option {
 	return func(w *Worker, _ *[]worker.Option[json.RawMessage], _ *[]worker.RunOption) {
 		w.tombstone = q
@@ -171,11 +174,12 @@ func (w *Worker) transferID(t *entroq.Task) string {
 	return "xfer-" + base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
-// TombstoneQueue returns the default tombstone queue for an inbox. A
-// delete-reaper should watch this queue (or whatever WithTombstoneQueue
-// overrides it to) to reap crash orphans.
+// TombstoneQueue returns the default tombstone queue for an inbox. Its name
+// carries a gc=0 component so the destination server's built-in garbage
+// collector reaps crash orphans once their TTL (arrival time) elapses; no
+// separate reaper is needed as long as that server runs GC, which is the default.
 func TombstoneQueue(inbox string) string {
-	return path.Join(inbox, "_tombstone")
+	return path.Join(inbox, "_tombstone", "gc=0")
 }
 
 // New creates a pull Worker ready to be configured by Run.
@@ -187,9 +191,9 @@ func New() *Worker {
 // (the instance tasks are claimed from); WithDest supplies the destination
 // client. Blocks until ctx is canceled or an unrecoverable error occurs.
 //
-// Run delivers and cleans up its own tombstones on the happy path, but a
-// delete-reaper should still be pointed at the tombstone queue (WithTombstoneQueue,
-// default <inbox>/_tombstone) to reap orphans left by crashes.
+// Run delivers and cleans up its own tombstones on the happy path; crash orphans
+// are reaped by the destination server's built-in GC, since the tombstone queue
+// (see TombstoneQueue) carries a gc= marker.
 func Run(ctx context.Context, src *entroq.EntroQ, opts ...Option) error {
 	w := New()
 	var workerOpts []worker.Option[json.RawMessage]


### PR DESCRIPTION
## Built-in, best-effort garbage collection

EntroQ servers now reap queues that opt in by name, so fault-tolerance recipes
(async response queues, eqlink dedup tombstones) no longer need a side process
for cleanup.

### What's here

- **`gc=` convention + `pkg/gc`.** A queue whose name carries a `/gc=<timestamp>`
  component (empty/`0`/Unix-seconds/RFC3339, last-wins) is drained once that time
  passes, via ordinary claim/delete so a task a worker holds is never touched.
  `pkg/gc` is a reusable, matcher-scoped, batched collector.
- **Server-side GC.** `eqpg`/`eqmem`/`eqredis serve` run it in-process (via
  `eqsvcgrpc`), **on by default**, with `--no_gc` to opt out and `--gc_interval`
  to tune (default 1m). `Close` cancels and joins the loop before closing the backend.
- **Telemetry.** `entroq_gc_deleted_total` / `errors_total` /
  `sweep_duration_seconds`, plus Grafana panels, sharing the queue-size labels.
- **async generalization.** The sender stamps response queues `gc=<deadline+grace>`
  (grace moved from the collector to the sender, `--response_grace`).
- **eqlink tombstones.** `pull`/`push` dedup tombstones are reaped by the
  destination server's GC (tombstone queue carries `gc=0`); the bespoke reaper is
  replaced by an opt-in `--run-gc` fallback.

### Behavior changes

- **`eqlink run --run-gc` defaults off** -- the server collects now. An e2e test
  (`pkg/async/TestServiceGCWithSidecarGCOff`) validates the topology: a live
  request is unharmed while service GC scans, and an orphan is reaped.
- **`exp=` alias dropped** in favor of `gc=` only. Pre-1.5.0 in-flight response
  queues go uncollected by the new GC; they're ephemeral, so the gap is one-time.

### Known gap / follow-up

- Built-in GC lives in `eqsvcgrpc`, so a **direct-to-PostgreSQL client** (the
  many-clients-one-DB model, no server in front) gets no built-in GC. Documented
  in the `eqpg` package docs; such deployments run their own collector (a
  standalone loop, or `eqlink pull/push --run-gc`). A follow-up will explore
  native PG GC by folding a pass into the leader heartbeat.

Targets **v1.5.0**.
